### PR TITLE
remove packageInfo, use env vars with babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,6 +9,12 @@
     }
   }], "react"],
   "plugins": [
+    ["transform-inline-environment-variables", {
+      "include": [
+        "PACKAGE_NAME",
+        "PACKAGE_VERSION"
+      ]
+    }],
     "transform-object-rest-spread",
     "transform-class-properties",
     "transform-runtime",

--- a/build.js
+++ b/build.js
@@ -4,6 +4,8 @@ const shell = require('shelljs');
 const chalk = require('chalk');
 const fs = require('fs');
 
+require('./env'); // set variables in process.env
+
 const NPM_DIR = `dist`;
 const BABEL_CMD = `babel src -d ${NPM_DIR}/src -s`;
 

--- a/env.js
+++ b/env.js
@@ -1,7 +1,11 @@
-// Support storing environment variables in a file named "testenv"
 const path = require('path');
 const dotenv = require('dotenv');
 const fs = require('fs');
+
+// Read information from package.json and expose as environment variables
+const PACKAGE = require('./package.json');
+process.env.PACKAGE_NAME = PACKAGE.name;
+process.env.PACKAGE_VERSION = PACKAGE.version;
 
 // Read environment variables from "testenv". Override environment vars if they are already set.
 const TESTENV = path.resolve(__dirname, 'testenv');

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "react-router-dom": ">=5.1.0"
   },
   "devDependencies": {
-    "lerna": "^3.22.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.1.1",
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
@@ -63,6 +63,7 @@
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "jest": "^23.6.0",
+    "lerna": "^3.22.1",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10",
     "protractor": "^5.4.2",

--- a/src/AuthService.js
+++ b/src/AuthService.js
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+/* global process */
 import {
   assertIssuer,
   assertClientId,
@@ -16,8 +17,6 @@ import {
   buildConfigObject
 } from '@okta/configuration-validation';
 import OktaAuth from '@okta/okta-auth-js';
-
-import packageInfo from './packageInfo';
 
 class AuthService {
   constructor(config) {
@@ -33,7 +32,7 @@ class AuthService {
     assertRedirectUri(authConfig.redirectUri);
 
     this._oktaAuth = new OktaAuth(authConfig);
-    this._oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${this._oktaAuth.userAgent}`;
+    this._oktaAuth.userAgent = `${process.env.PACKAGE_NAME}/${process.env.PACKAGE_VERSION} ${this._oktaAuth.userAgent}`;
     this._config = authConfig; // use normalized config
     this._pending = {}; // manage overlapping async calls 
 

--- a/src/packageInfo.js
+++ b/src/packageInfo.js
@@ -1,4 +1,0 @@
-export default {
-  'name': '@okta/okta-react',
-  'version': '3.0.7'
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,6 +4116,11 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-inline-environment-variables@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.3.tgz#a3b09883353be8b5e2336e3ff1ef8a5d93f9c489"
+  integrity sha1-o7CYgzU76LXiM24/8e+KXZP5xIk=
+
 babel-plugin-transform-object-rest-spread@6.26.0, babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"


### PR DESCRIPTION
removes packageInfo, which was being generated by a script.
uses environment variables w/ babel to set user agent with current version in transpiled code