### PR TITLE
fix: SecureRoute should call login only once until authenticated

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest current file",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": [
+        "--runInBand",
+        "--no-cache",
+        "${relativeFile}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@okta/configuration-validation": "^0.4.1",
-    "@okta/okta-auth-js": "^3.2.5"
+    "@okta/okta-auth-js": "^3.2.6"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/src/AuthService.js
+++ b/src/AuthService.js
@@ -205,6 +205,7 @@ class AuthService {
       return await this.redirect(additionalParams);
     } finally {
       this._pending.handleLogin = null;
+      this.emitAuthState({ ...this.getAuthState(), isPending: false });
     }
   }
 

--- a/src/SecureRoute.js
+++ b/src/SecureRoute.js
@@ -10,23 +10,31 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useOktaAuth } from './OktaContext';
 import { Route, useRouteMatch } from 'react-router-dom';
 
 const SecureRoute = ( props ) => { 
   const { authService, authState } = useOktaAuth();
   const match = useRouteMatch(props);
+  const pendingLogin = useRef(false);
 
   useEffect(() => {
     // Only process logic if the route matches
     if (!match) {
       return;
     }
-    // Start login if and only if app has decided it is not logged inn
-    if(!authState.isAuthenticated && !authState.isPending) { 
+
+    if (authState.isAuthenticated) {
+      pendingLogin.current = false;
+      return;
+    }
+
+    // Start login if app has decided it is not logged in and there is no pending signin
+    if(!authState.isAuthenticated && !authState.isPending && !pendingLogin.current) { 
+      pendingLogin.current = true;
       authService.login();
-    }  
+    }
   }, [authState.isPending, authState.isAuthenticated, authService, match]);
 
   if (!authState.isAuthenticated) {

--- a/test/e2e/harness/src/App.js
+++ b/test/e2e/harness/src/App.js
@@ -35,14 +35,14 @@ class App extends Component {
   
   render() {
     const { ISSUER, CLIENT_ID } = process.env;
-    const { pkce, redirectUri } = this.props;
+    const { pkce, redirectUri, customLogin } = this.props;
     return (
       <React.StrictMode>
         <Security issuer={ISSUER}
                   clientId={CLIENT_ID}
                   disableHttpsCheck={true}
                   redirectUri={redirectUri}
-                  onAuthRequired={this.onAuthRequired}
+                  onAuthRequired={customLogin ? this.onAuthRequired : undefined}
                   pkce={pkce}>
           <Switch>
             <Route path='/login' component={CustomLogin}/>

--- a/test/e2e/harness/src/index.js
+++ b/test/e2e/harness/src/index.js
@@ -23,10 +23,11 @@ import { BrowserRouter as Router } from 'react-router-dom';
 const url = new URL(window.location.href);
 const pkce = !!url.searchParams.get('pkce') || url.pathname.indexOf('pkce/callback') >= 0;
 const redirectUri = window.location.origin + (pkce ? '/pkce/callback' : '/implicit/callback');
+const customLogin = !!url.searchParams.get('customLogin');
 
 ReactDOM.render(
   <Router>
-    <App pkce={pkce} redirectUri={redirectUri} />
+    <App pkce={pkce} redirectUri={redirectUri} customLogin={customLogin} />
   </Router>
   , document.getElementById('root')
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2533,10 +2533,10 @@
   dependencies:
     lodash "^4.17.15"
 
-"@okta/okta-auth-js@^3.2.5":
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-3.2.5.tgz#46ab9f35be37fc58e970997342799fe0a72c3e5e"
-  integrity sha512-QbyRhDrBI9CdKBFpikPFjR2zmwOIQSndx+/g9YVuQ25QrxUnVhq/nAg/EXMQtrOQVtcb99Vx5AIfm1DWnKV31A==
+"@okta/okta-auth-js@^3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-3.2.6.tgz#9eb457ee46576ade2cab9c2524096f0c91f17edf"
+  integrity sha512-4N3XkaHUs2QbUR3ymg+PtoPAGluU3IkBK1kIfoYWeONXTyz0v/PpAKgHDe3RJkvRkDQzvAJDdT6VL29wIYE1ww==
   dependencies:
     Base64 "0.3.0"
     cross-fetch "^3.0.0"


### PR DESCRIPTION
This fixes a regression that appeared in 3.0.9. The SecureRoute will call `login` repeatedly because the `login` method is updating the auth state. This was not noticed in our test harness because it was using a custom login page set with `onAuthRequired` which was calling `redirect` directly, which does not change the state.

The fix involves `useRef` to hold an internal variable inside SecureRoute. This will disable calling `login` more than once while the user is unauthenticated. When the state shows that the user is authenticated, this value will be reset, allowing the SecureRoute to function again if the user should become unauthenticated in the future.

A queryParam `customLogin` was added to the test harness app, allowing us to manually test the custom login page. However, it is disabled by default so our E2E test will perform the default flow.

A unit test is added to confirm the logic in SecureRoute.

Also updated auth-js to latests 3.2.x version and added a .vscode launch.json.