### PR TITLE
Add loadingComponent prop to LoginCallback component

### DIFF
--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -19,7 +19,7 @@ interface LoginCallbackProps {
   loadingComponent?: React.ReactElement;
 }
 
-const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingComponent }) => { 
+const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingComponent = null }) => { 
   const { oktaAuth, authState } = useOktaAuth();
   const authStateReady = !authState.isPending;
 

--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -14,9 +14,12 @@ import * as React from 'react';
 import { useOktaAuth } from './OktaContext';
 import OktaError from './OktaError';
 
-const LoginCallback: React.FC<{ 
-  errorComponent?: React.ComponentType<{ error: Error }>
-}> = ({ errorComponent }) => { 
+interface LoginCallbackProps {
+  errorComponent?: React.ComponentType<{ error: Error }>;
+  loadingComponent?: React.ReactElement;
+}
+
+const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingComponent }) => { 
   const { oktaAuth, authState } = useOktaAuth();
   const authStateReady = !authState.isPending;
 
@@ -26,11 +29,11 @@ const LoginCallback: React.FC<{
     oktaAuth.handleLoginRedirect();
   }, [oktaAuth]);
 
-  if(authStateReady && authState.error) { 
+  if (authStateReady && authState.error) { 
     return <ErrorReporter error={authState.error}/>;
   }
 
-  return null;
+  return loadingComponent;
 };
 
 export default LoginCallback;


### PR DESCRIPTION
### Actual result
The LoginCallback components shows an empty white page while the authentication is being performed

### What this PR does
This PR gives the developer the possibility to set any custom component that he/she wants to show while Okta's authentication is being done instead of just returning a null value