### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,17 +303,20 @@ export default MessageList = () => {
 
   useEffect( () => { 
     if(authState.isAuthenticated) { 
-      try {
-        const response = await fetch('http://localhost:{serverPort}/api/messages', {
-          headers: {
-            Authorization: 'Bearer ' + authState.accessToken
-          }
-        });
-        const data = await response.json();
-        setMessages( data.messages );
-      } catch (err) {
-        // handle error as needed
+      const apiCall = async () => {
+        try {
+          const response = await fetch('http://localhost:{serverPort}/api/messages', {
+            headers: {
+              Authorization: 'Bearer ' + authState.accessToken.accessToken
+            }
+          });
+          const data = await response.json();
+          setMessages( data.messages );
+        } catch (err) {
+          // handle error as needed
+        }
       }
+      apiCall();
     }
   }, [authState] );
 


### PR DESCRIPTION
Fix Code snippet in Use the Access Token (function-based) sample

In the useEffect call wrap the async call inside a async function. When accessing the access token from authState add '.accessToken' to get the token instead of the accessToken object.