### PR TITLE
Add loadingComponent prop to LoginCallback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.1.0
+
+### Features
+
+- [#67](https://github.com/okta/okta-react/pull/67) Adds `loadingComponent` prop to `LoginCallback` component
+
 # 6.0.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-react",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "React support for Okta",
   "private": true,
   "scripts": {

--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -20,7 +20,7 @@ interface LoginCallbackProps {
   loadingComponent?: React.ReactElement;
 }
 
-const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingComponent, onAuthResume }) => { 
+const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingComponent = null, onAuthResume }) => { 
   const { oktaAuth, authState } = useOktaAuth();
   const [callbackError, setCallbackError] = React.useState(null);
 

--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -14,10 +14,13 @@ import * as React from 'react';
 import { useOktaAuth, OnAuthResumeFunction } from './OktaContext';
 import OktaError from './OktaError';
 
-const LoginCallback: React.FC<{ 
-  errorComponent?: React.ComponentType<{ error: Error }>,
-  onAuthResume?: OnAuthResumeFunction,
-}> = ({ errorComponent, onAuthResume }) => { 
+interface LoginCallbackProps {
+  errorComponent?: React.ComponentType<{ error: Error }>;
+  onAuthResume?: OnAuthResumeFunction;
+  loadingComponent?: React.ReactElement;
+}
+
+const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingComponent, onAuthResume }) => { 
   const { oktaAuth, authState } = useOktaAuth();
   const [callbackError, setCallbackError] = React.useState(null);
 
@@ -43,7 +46,7 @@ const LoginCallback: React.FC<{
     return <ErrorReporter error={displayError}/>;
   }
 
-  return null;
+  return loadingComponent;
 };
 
 export default LoginCallback;

--- a/test/e2e/harness/e2e/App.test.js
+++ b/test/e2e/harness/e2e/App.test.js
@@ -15,7 +15,8 @@ import {
   AppPage,
   OktaSignInPage,
   ProtectedPage,
-  SessionTokenSignInPage
+  SessionTokenSignInPage,
+  LoginCallbackPage
 } from './page-objects';
 
 describe('React + Okta App', () => {
@@ -23,12 +24,14 @@ describe('React + Okta App', () => {
   let oktaLoginPage;
   let protectedPage;
   let sessionTokenSignInPage;
+  let loginCallbackPage;
 
   beforeEach(() => {
     appPage = new AppPage();
     oktaLoginPage = new OktaSignInPage();
     protectedPage = new ProtectedPage();
     sessionTokenSignInPage = new SessionTokenSignInPage();
+    loginCallbackPage = new LoginCallbackPage();
   });
 
   describe('implicit flow', () => {
@@ -95,6 +98,7 @@ describe('React + Okta App', () => {
         password: process.env.PASSWORD
       });
   
+      loginCallbackPage.waitUntilVisible();
       protectedPage.waitUntilVisible('?pkce=1&state=bar#baz');
       expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
   
@@ -125,6 +129,7 @@ describe('React + Okta App', () => {
         password: process.env.PASSWORD
       });
   
+      loginCallbackPage.waitUntilVisible();
       appPage.waitUntilVisible();
       expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
   

--- a/test/e2e/harness/e2e/page-objects/login-callback.po.js
+++ b/test/e2e/harness/e2e/page-objects/login-callback.po.js
@@ -10,8 +10,16 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export { AppPage } from './page-objects/app.po';
-export { OktaSignInPage } from './page-objects/okta-signin.po';
-export { ProtectedPage } from './page-objects/protected.po';
-export { SessionTokenSignInPage } from './page-objects/sessionToken-signin.po';
-export { LoginCallbackPage } from './page-objects/login-callback.po';
+import { by, element } from 'protractor';
+import { Util } from '../util';
+
+export class LoginCallbackPage {
+    waitUntilVisible() {
+      Util.waitElement(this.loadingComponent());
+    }
+
+    loadingComponent() {
+      return element(by.id('login-callback-loading'));
+    }
+
+}

--- a/test/e2e/harness/src/App.tsx
+++ b/test/e2e/harness/src/App.tsx
@@ -48,11 +48,19 @@ const App: React.FC<{
       >
         <Switch>
           <Route path='/login' component={CustomLogin} />
-          <Route path='/widget-login' render={ (props) => <WidgetLogin {...props} baseUrl={baseUrl} /> }/>
+          <Route path='/widget-login' render={ (props) => 
+            <WidgetLogin {...props} baseUrl={baseUrl} />
+          } />
           <Route path='/sessionToken-login' component={SessionTokenLogin} />
           <SecureRoute exact path='/protected' component={Protected} />
           <Route path='/implicit/callback' component={LoginCallback} />
-          <Route path='/pkce/callback' render={ (props) => <LoginCallback {...props} onAuthResume={ onAuthResume } /> } />
+          <Route path='/pkce/callback' render={ (props) => 
+            <LoginCallback 
+              {...props} 
+              onAuthResume={ onAuthResume } 
+              loadingComponent={ <p id='login-callback-loading'>Loading...</p> }
+            />
+          } />
           <Route path='/' component={Home} />
         </Switch>
       </Security>

--- a/test/jest/loginCallback.test.tsx
+++ b/test/jest/loginCallback.test.tsx
@@ -97,7 +97,7 @@ describe('<LoginCallback />', () => {
       };
 
       const MyErrorComponent = ({ error }) => { 
-      return (<p>Override: {error.has}</p>);
+        return (<p>Override: {error.has}</p>);
       };
 
       const wrapper = mount(
@@ -172,6 +172,58 @@ describe('<LoginCallback />', () => {
         await wrapper.update(); // render error
         expect(wrapper.text()).toBe('Error: ' + errorMsg);
       });
+    });
+  });
+
+  describe('shows loading', () => {
+    it('does not render loading by default', () => { 
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <LoginCallback />
+        </Security>
+      );
+      expect(wrapper.text()).toBe('');
+    });
+
+    it('custom loading component can be passed to render during loading', () => {
+      const MyLoadingComponent = (<p>loading...</p>);
+
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <LoginCallback loadingComponent={MyLoadingComponent}/>
+        </Security>
+      );
+      expect(wrapper.text()).toBe('loading...');
+    });
+
+    it('does not render loading component on error', () => {
+      authState = {
+        isAuthenticated: true,
+        error: new Error('oh drat!')
+      };
+      const MyLoadingComponent = (<p>loading...</p>);
+
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <LoginCallback loadingComponent={MyLoadingComponent}/>
+        </Security>
+      );
+      expect(wrapper.text()).toBe('Error: oh drat!');
+    });
+
+    it('renders loading component if onAuthResume is passed', async () => { 
+      oktaAuth.isInteractionRequired = jest.fn().mockImplementation( () => true );
+      const resumeFunction = jest.fn();
+      const MyLoadingComponent = (<p>loading...</p>);
+      jest.spyOn(React, 'useEffect').mockImplementation(f => f())
+
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <LoginCallback onAuthResume={resumeFunction} loadingComponent={MyLoadingComponent}/>
+        </Security>
+      );
+      expect(resumeFunction).toHaveBeenCalled();
+      expect(wrapper.text()).toBe('loading...');
     });
   });
 


### PR DESCRIPTION
Quoting original PR( #58 ) from @ericlifs:

### Actual result
The LoginCallback components shows an empty white page while the authentication is being performed

### What this PR does
This PR gives the developer the possibility to set any custom component that he/she wants to show while Okta's authentication is being done instead of just returning a null value