### PR TITLE
fix: do not duplicate basename in the URI during post-callback navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.1.1
+
+### Bug Fixes
+
+- [#56](https://github.com/okta/okta-react/pull/68) Fixes `basename` duplication on navigate from callback route.
+
 # 4.1.0
 
 ### Other

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,5 +29,5 @@ module.exports = {
     './test/jest/setup.ts'
   ],
   testEnvironment: 'jsdom',
-  transform: { '^.+\\.tsx?$': 'ts-jest' }
+  transform: { '^.+\\.tsx?$': 'ts-jest' },
 };

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -46,7 +46,9 @@ const Security: React.FC<{
     // Add default restoreOriginalUri callback
     if (!oktaAuth.options.restoreOriginalUri) {
       oktaAuth.options.restoreOriginalUri = async (_, originalUri) => {
-        history.replace(toRelativeUrl(originalUri, window.location.origin));
+        const basepath = history.createHref({});
+        const originalUriWithoutBasepath = originalUri.replace(basepath, '/');
+        history.replace(toRelativeUrl(originalUriWithoutBasepath, window.location.origin));
       };
     }
 

--- a/test/jest/setup.ts
+++ b/test/jest/setup.ts
@@ -14,3 +14,6 @@ import * as Enzyme from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+global.console.warn = function() {};


### PR DESCRIPTION
Resolves: [OKTA-353934](https://oktainc.atlassian.net/browse/OKTA-353934)

Make use of history [API](https://github.com/ReactTraining/history/blob/28c89f4091ae9e1b0001341ea60c629674e83627/docs/api-reference.md#historycreatehrefto-to) to get basename value.
Basename is being [prepended](https://github.com/ReactTraining/history/blob/v4/modules/createBrowserHistory.js#L151) to URI on history change. 
~Omit basename when storing `originalUri`.~