### PR TITLE
Decouple Security from react-router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-- [#71](https://github.com/okta/okta-react/pull/71) Removes adding default `restoreOriginalUri` callback in `Security`
+- [#71](https://github.com/okta/okta-react/pull/71) Added required prop `restoreOriginalUri` to `Security`
 
 # 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-- [#71](https://github.com/okta/okta-react/pull/71) Added required prop `restoreOriginalUri` to `Security`
+- [#71](https://github.com/okta/okta-react/pull/71) Adds required prop `restoreOriginalUri` to `Security` that will override `restoreOriginalUri` callback of `oktaAuth`
 
 # 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.0.0
+
+### Breaking Changes
+
+- [#71](https://github.com/okta/okta-react/pull/71) Removes adding default `restoreOriginalUri` callback in `Security`
+
 # 4.1.0
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ export default MyComponent = () => {
 
 ### Migrating from 4.x to 5.x
 
-From version 5.0, the Security component requires prop [restoreOriginalUri](#restoreoriginaluri). Example of implementation of this callback for `react-router`:
+From version 5.0, the Security component explicitly requires prop [restoreOriginalUri](#restoreoriginaluri). Example of implementation of this callback for `react-router`:
 
 ```jsx
 import { Security } from '@okta/okta-react';

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import Home from './Home';
 import Protected from './Protected';
 
-class SecureApp extends Component {
+class App extends Component {
   constructor(props) {
     super(props);
     this.oktaAuth = new OktaAuth({
@@ -151,14 +151,12 @@ class SecureApp extends Component {
   }
 }
 
-const AppWithRouterAccess = withRouter(SecureApp);
-class App extends Component {
+const AppWithRouterAccess = withRouter(App);
+export default class extends Component {
   render() {
     return (<Router><AppWithRouterAccess/></Router>);
   }
 }
-
-export default App;
 ```
 
 #### Creating React Router Routes with function-based components
@@ -483,7 +481,35 @@ export default MyComponent = () => {
 
 ### Migrating from 4.x to 5.x
 
-From version 5.0, the Security component have required prop [restoreOriginalUri](#restoreoriginaluri). See [example](#example) of implementation of this callback for `react-router`.
+From version 5.0, the Security component requires prop [restoreOriginalUri](#restoreoriginaluri). Example of implementation of this callback for `react-router`:
+
+```jsx
+import { Security } from '@okta/okta-react';
+import { useHistory } from 'react-router-dom';
+import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
+
+const oktaAuth = new OktaAuth({
+  issuer: 'https://{yourOktaDomain}.com/oauth2/default',
+  clientId: '{clientId}',
+  redirectUri: window.location.origin + '/login/callback'
+});
+
+export default App = () => {
+  const history = useHistory();
+  const restoreOriginalUri = async (_oktaAuth, originalUri) => {
+    history.replace(toRelativeUrl(originalUri, window.location.origin));
+  };
+
+  return (
+    <Security
+      oktaAuth={oktaAuth}
+      restoreOriginalUri={restoreOriginalUri}
+    >
+      {/* some routes here */}
+    </Security>
+  );
+};
+```
 
 ### Migrating from 3.x to 4.x
 
@@ -502,7 +528,7 @@ import { Security } from '@okta/okta-react';
 
 const oktaAuth = new OktaAuth(oidcConfig);
 export default () => (
-  <Security oktaAuth={oktaAuth} onAuthRequired={customAuthHandler} restoreOriginalUri={restoreOriginalUri}>
+  <Security oktaAuth={oktaAuth} onAuthRequired={customAuthHandler}>
     // children component
   </Security>
 );

--- a/README.md
+++ b/README.md
@@ -481,6 +481,10 @@ export default MyComponent = () => {
 
 ## Migrating between versions
 
+### Migrating from 4.x to 5.x
+
+From version 5.0, the Security component have required prop [restoreOriginalUri](#restoreoriginaluri). See [example](#example) of implementation of this callback for `react-router`.
+
 ### Migrating from 3.x to 4.x
 
 #### Updating the Security component

--- a/README.md
+++ b/README.md
@@ -133,18 +133,18 @@ class SecureApp extends Component {
     this.oktaAuth = new OktaAuth({
       issuer: 'https://{yourOktaDomain}.com/oauth2/default',
       clientId: '{clientId}',
-      redirectUri: window.location.origin + '/login/callback',
-      restoreOriginalUri: async (_oktaAuth, originalUri) => {
-        props.history.replace(toRelativeUrl(originalUri, window.location.origin));
-      }
+      redirectUri: window.location.origin + '/login/callback'
     });
+    this.restoreOriginalUri = async (_oktaAuth, originalUri) => {
+      props.history.replace(toRelativeUrl(originalUri, window.location.origin));
+    };
   }
 
   render() {
     return (
-      <Security oktaAuth={this.oktaAuth}>
-        <Route path='/' exact={true} component={Home}/>
-        <SecureRoute path='/protected' component={Protected}/>
+      <Security oktaAuth={this.oktaAuth} restoreOriginalUri={this.restoreOriginalUri} >
+        <Route path='/' exact={true} component={Home} />
+        <SecureRoute path='/protected' component={Protected} />
         <Route path='/login/callback' component={LoginCallback} />
       </Security>
     );
@@ -176,17 +176,17 @@ const App = () => {
   const oktaAuth = new OktaAuth({
     issuer: 'https://{yourOktaDomain}.com/oauth2/default',
     clientId: '{clientId}',
-    redirectUri: window.location.origin + '/login/callback',
-    restoreOriginalUri: async (_oktaAuth, originalUri) => {
-      history.replace(toRelativeUrl(originalUri, window.location.origin));
-    }
+    redirectUri: window.location.origin + '/login/callback'
   });
+  const restoreOriginalUri = async (_oktaAuth, originalUri) => {
+    history.replace(toRelativeUrl(originalUri, window.location.origin));
+  };
 
   return (
     <Router>
-      <Security oktaAuth={oktaAuth}>
-        <Route path='/' exact={true} component={Home}/>
-        <SecureRoute path='/protected' component={Protected}/>
+      <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+        <Route path='/' exact={true} component={Home} />
+        <SecureRoute path='/protected' component={Protected} />
         <Route path='/login/callback' component={LoginCallback} />
       </Security>
     </Router>
@@ -358,6 +358,10 @@ export default MessageList = () => {
 
 *(required)* The pre-initialized [oktaAuth][Okta Auth SDK] instance. See [Configuration Reference](https://github.com/okta/okta-auth-js#configuration-reference) for details of how to initialize the instance.
 
+#### restoreOriginalUri
+
+*(required)* Callback function. Called to restore original () during [oktaAuth.handleLoginRedirect()](https://github.com/okta/okta-auth-js#handleloginredirecttokens) is called. Will override [restoreOriginalUri option of oktaAuth](https://github.com/okta/okta-auth-js#restoreoriginaluri)
+
 #### onAuthRequired
 
 *(optional)* Callback function. Called when authentication is required. If this is not supplied, `okta-react` redirects to Okta. This callback will receive [oktaAuth][Okta Auth SDK] instance as the first function parameter. This is triggered when a [SecureRoute](#secureroute) is accessed without authentication. A common use case for this callback is to redirect users to a custom login route when authentication is required for a [SecureRoute](#secureroute).
@@ -366,7 +370,7 @@ export default MessageList = () => {
 
 ```jsx
 import { useHistory } from 'react-router-dom';
-import { OktaAuth } from '@okta/okta-auth-js';
+import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 
 const oktaAuth = new OktaAuth({
   issuer: 'https://{yourOktaDomain}.com/oauth2/default',
@@ -383,10 +387,15 @@ export default App = () => {
     history.push('/login');
   };
 
+  const restoreOriginalUri = async (_oktaAuth, originalUri) => {
+    history.replace(toRelativeUrl(originalUri, window.location.origin));
+  };
+
   return (
     <Security
       oktaAuth={oktaAuth}
       onAuthRequired={customAuthHandler}
+      restoreOriginalUri={restoreOriginalUri}
     >
       <Route path='/login' component={CustomLoginComponent}>
       {/* some routes here */}
@@ -415,8 +424,8 @@ class App extends Component {
   render() {
     return (
       <Router>
-        <Security oktaAuth={oktaAuth}>
-          <Route path='/' exact={true} component={Home}/>
+        <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+          <Route path='/' exact={true} component={Home} />
           <Route path='/login/callback' component={LoginCallback} />
         </Security>
       </Router>
@@ -489,7 +498,7 @@ import { Security } from '@okta/okta-react';
 
 const oktaAuth = new OktaAuth(oidcConfig);
 export default () => (
-  <Security oktaAuth={oktaAuth} onAuthRequired={customAuthHandler}>
+  <Security oktaAuth={oktaAuth} onAuthRequired={customAuthHandler} restoreOriginalUri={restoreOriginalUri}>
     // children component
   </Security>
 );

--- a/README.md
+++ b/README.md
@@ -169,13 +169,14 @@ import { useHistory } from 'react-router-dom';
 import Home from './Home';
 import Protected from './Protected';
 
+const oktaAuth = new OktaAuth({
+  issuer: 'https://{yourOktaDomain}.com/oauth2/default',
+  clientId: '{clientId}',
+  redirectUri: window.location.origin + '/login/callback'
+});
+
 const App = () => {
   const history = useHistory();
-  const oktaAuth = new OktaAuth({
-    issuer: 'https://{yourOktaDomain}.com/oauth2/default',
-    clientId: '{clientId}',
-    redirectUri: window.location.origin + '/login/callback'
-  });
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
     history.replace(toRelativeUrl(originalUri, window.location.origin));
   };
@@ -481,7 +482,8 @@ export default MyComponent = () => {
 
 ### Migrating from 4.x to 5.x
 
-From version 5.0, the Security component explicitly requires prop [restoreOriginalUri](#restoreoriginaluri). Example of implementation of this callback for `react-router`:
+From version 5.0, the Security component explicitly requires prop [restoreOriginalUri](#restoreoriginaluri) to decouple from `react-router`. 
+Example of implementation of this callback for `react-router`:
 
 ```jsx
 import { Security } from '@okta/okta-react';

--- a/src/OktaContext.ts
+++ b/src/OktaContext.ts
@@ -14,6 +14,8 @@ import { AuthState, OktaAuth } from '@okta/okta-auth-js';
 
 export type OnAuthRequiredFunction = (oktaAuth: OktaAuth) => Promise<void> | void;
 
+export type RestoreOriginalUriFunction = (oktaAuth: OktaAuth, originalUri: string) => Promise<void> | void;
+
 export interface IOktaContext {
     oktaAuth: OktaAuth;
     authState: AuthState;

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -44,6 +44,9 @@ const Security: React.FC<{
     }
 
     // Add default restoreOriginalUri callback
+    if (oktaAuth.options.restoreOriginalUri && restoreOriginalUri) {
+      console.warn('Two restoreOriginalUri callbacks provied: one from prop to Security, another one from oktaAuth options. Please remove second one.');
+    }
     oktaAuth.options.restoreOriginalUri = async (oktaAuth: any, originalUri: string) => {
       restoreOriginalUri(oktaAuth, originalUri);
     };

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -16,15 +16,15 @@ import OktaContext, { OnAuthRequiredFunction, RestoreOriginalUriFunction } from 
 import OktaError from './OktaError';
 
 const Security: React.FC<{
-  oktaAuth: OktaAuth, 
+  oktaAuth: OktaAuth,
+  restoreOriginalUri: RestoreOriginalUriFunction, 
   onAuthRequired?: OnAuthRequiredFunction,
-  children?: React.ReactNode,
-  restoreOriginalUri: RestoreOriginalUriFunction
+  children?: React.ReactNode
 } & React.HTMLAttributes<HTMLDivElement>> = ({ 
-  oktaAuth, 
+  oktaAuth,
+  restoreOriginalUri, 
   onAuthRequired, 
-  children,
-  restoreOriginalUri
+  children
 }) => { 
   const [authState, setAuthState] = React.useState(() => {
     if (!oktaAuth) {

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -11,8 +11,7 @@
  */
 
 import * as React from 'react';
-import { useHistory } from 'react-router-dom';
-import { toRelativeUrl, AuthSdkError, OktaAuth } from '@okta/okta-auth-js';
+import { AuthSdkError, OktaAuth } from '@okta/okta-auth-js';
 import OktaContext, { OnAuthRequiredFunction } from './OktaContext';
 import OktaError from './OktaError';
 
@@ -23,9 +22,8 @@ const Security: React.FC<{
 } & React.HTMLAttributes<HTMLDivElement>> = ({ 
   oktaAuth, 
   onAuthRequired, 
-  children 
+  children
 }) => { 
-  const history = useHistory();
   const [authState, setAuthState] = React.useState(() => {
     if (!oktaAuth) {
       return { 
@@ -43,13 +41,6 @@ const Security: React.FC<{
       return;
     }
 
-    // Add default restoreOriginalUri callback
-    if (!oktaAuth.options.restoreOriginalUri) {
-      oktaAuth.options.restoreOriginalUri = async (_, originalUri) => {
-        history.replace(toRelativeUrl(originalUri, window.location.origin));
-      };
-    }
-
     // Add okta-react userAgent
     oktaAuth.userAgent = `${process.env.PACKAGE_NAME}/${process.env.PACKAGE_VERSION} ${oktaAuth.userAgent}`;
 
@@ -64,7 +55,7 @@ const Security: React.FC<{
     }
 
     return () => oktaAuth.authStateManager.unsubscribe();
-  }, [oktaAuth, history]);
+  }, [oktaAuth]);
 
   if (!oktaAuth) {
     const err = new AuthSdkError('No oktaAuth instance passed to Security Component.');

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -45,7 +45,7 @@ const Security: React.FC<{
 
     // Add default restoreOriginalUri callback
     if (oktaAuth.options.restoreOriginalUri && restoreOriginalUri) {
-      console.warn('Two restoreOriginalUri callbacks provied: one from prop to Security, another one from oktaAuth options. Please remove second one.');
+      console.warn('Two custom restoreOriginalUri callbacks are detected. The one from the OktaAuth configuration will be overridden by the provided restoreOriginalUri prop from the Security component.');
     }
     oktaAuth.options.restoreOriginalUri = async (oktaAuth: any, originalUri: string) => {
       restoreOriginalUri(oktaAuth, originalUri);

--- a/test/e2e/harness/src/App.tsx
+++ b/test/e2e/harness/src/App.tsx
@@ -12,7 +12,7 @@
 
 import * as React from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
-import { OktaAuth } from '@okta/okta-auth-js';
+import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import { Security, LoginCallback, SecureRoute } from '@okta/okta-react';
 import Home from './Home';
 import Protected from './Protected';
@@ -29,11 +29,16 @@ const App: React.FC<{
     history.push('/login');
   };
 
+  const restoreOriginalUri = async (_oktaAuth: OktaAuth, originalUri: string) => {
+    history.replace(toRelativeUrl(originalUri, window.location.origin));
+  };
+
   return (
     <React.StrictMode>
       <Security
         oktaAuth={oktaAuth}
         onAuthRequired={customLogin ? onAuthRequired : undefined}
+        restoreOriginalUri={restoreOriginalUri}
       >
         <Switch>
           <Route path='/login' component={CustomLogin}/>

--- a/test/jest/loginCallback.test.tsx
+++ b/test/jest/loginCallback.test.tsx
@@ -19,6 +19,9 @@ describe('<LoginCallback />', () => {
   let oktaAuth;
   let authState;
   let mockProps;
+  const restoreOriginalUri = async (_, url) => {
+    location.href = url;
+  };
   beforeEach(() => {
     authState = {
       isPending: true
@@ -33,7 +36,10 @@ describe('<LoginCallback />', () => {
       isLoginRedirect: jest.fn().mockImplementation(() => false),
       handleLoginRedirect: jest.fn()
     };
-    mockProps = { oktaAuth };
+    mockProps = {
+      oktaAuth, 
+      restoreOriginalUri
+    };
   });
 
   it('renders the component', () => {

--- a/test/jest/secureRoute.test.tsx
+++ b/test/jest/secureRoute.test.tsx
@@ -13,7 +13,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { MemoryRouter, Route } from 'react-router-dom';
+import { MemoryRouter, Route, RouteProps } from 'react-router-dom';
 import SecureRoute from '../../src/SecureRoute';
 import Security from '../../src/Security';
 
@@ -305,7 +305,8 @@ describe('<SecureRoute />', () => {
         </MemoryRouter>
       );
       const secureRoute = wrapper.find(SecureRoute);
-      expect(secureRoute.find(Route).props().exact).toBe(true);
+      const props: RouteProps = secureRoute.find(Route).props();
+      expect(props.exact).toBe(true);
       expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
     });
 
@@ -322,7 +323,8 @@ describe('<SecureRoute />', () => {
         </MemoryRouter>
       );
       const secureRoute = wrapper.find(SecureRoute);
-      expect(secureRoute.find(Route).props().strict).toBe(true);
+      const props: RouteProps = secureRoute.find(Route).props();
+      expect(props.strict).toBe(true);
       expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
     });
 
@@ -339,7 +341,8 @@ describe('<SecureRoute />', () => {
         </MemoryRouter>
       );
       const secureRoute = wrapper.find(SecureRoute);
-      expect(secureRoute.find(Route).props().sensitive).toBe(true);
+      const props: RouteProps = secureRoute.find(Route).props();
+      expect(props.sensitive).toBe(true);
       expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
     });
 

--- a/test/jest/secureRoute.test.tsx
+++ b/test/jest/secureRoute.test.tsx
@@ -21,6 +21,9 @@ describe('<SecureRoute />', () => {
   let oktaAuth;
   let authState;
   let mockProps;
+  const restoreOriginalUri = async (_, url) => {
+    location.href = url;
+  };
 
   beforeEach(() => {
     authState = {
@@ -39,7 +42,10 @@ describe('<SecureRoute />', () => {
       signInWithRedirect: jest.fn(),
       setOriginalUri: jest.fn()
     };
-    mockProps = { oktaAuth };
+    mockProps = {
+      oktaAuth, 
+      restoreOriginalUri
+    };
   });
 
   describe('With changing authState', () => {

--- a/test/jest/security.test.tsx
+++ b/test/jest/security.test.tsx
@@ -21,6 +21,9 @@ import * as pkg from '../../package.json';
 describe('<Security />', () => {
   let oktaAuth;
   let initialAuthState;
+  const restoreOriginalUri = async (_, url) => {
+    location.href = url;
+  };
   beforeEach(() => {
     initialAuthState = {
       isInitialState: true
@@ -39,15 +42,27 @@ describe('<Security />', () => {
 
   it('should set userAgent for oktaAuth', () => {
     const mockProps = {
-      oktaAuth
+      oktaAuth,
+      restoreOriginalUri
     };
     mount(<Security {...mockProps} />);
     expect(oktaAuth.userAgent).toEqual(`${pkg.name}/${pkg.version} okta/okta-auth-js`);
   });
 
+  it('should set default restoreOriginalUri callback in oktaAuth.options', () => {
+    oktaAuth.options = {};
+    const mockProps = {
+      oktaAuth,
+      restoreOriginalUri
+    };
+    mount(<Security {...mockProps} />);
+    expect(oktaAuth.options.restoreOriginalUri).toBeDefined();
+  });
+
   it('gets initial state from oktaAuth and exposes it on the context', () => {
     const mockProps = {
-      oktaAuth
+      oktaAuth,
+      restoreOriginalUri
     };
     const MyComponent = jest.fn().mockImplementation(() => {
       const oktaProps = useOktaAuth();
@@ -77,7 +92,8 @@ describe('<Security />', () => {
       callback(newAuthState);
     });
     const mockProps = {
-      oktaAuth
+      oktaAuth,
+      restoreOriginalUri
     };
 
     const MyComponent = jest.fn()
@@ -110,7 +126,8 @@ describe('<Security />', () => {
   it('should not call updateAuthState when in login redirect state', () => {
     oktaAuth.isLoginRedirect = jest.fn().mockImplementation(() => true);
     const mockProps = {
-      oktaAuth
+      oktaAuth,
+      restoreOriginalUri
     };
     mount(
       <MemoryRouter>
@@ -143,7 +160,8 @@ describe('<Security />', () => {
       callback(mockAuthStates[stateCount]);
     });
     const mockProps = {
-      oktaAuth
+      oktaAuth,
+      restoreOriginalUri
     };
     const MyComponent = jest.fn()
       // first call
@@ -185,7 +203,8 @@ describe('<Security />', () => {
 
   it('should accept a className prop and render a component using the className', () => {
     const mockProps = {
-      oktaAuth
+      oktaAuth,
+      restoreOriginalUri
     };
     const wrapper = mount(
       <MemoryRouter>
@@ -216,7 +235,8 @@ describe('<Security />', () => {
         isPending: false
       };
       const mockProps = {
-        oktaAuth
+        oktaAuth,
+        restoreOriginalUri
       };
       const wrapper = mount(
         <Security {...mockProps}>
@@ -232,7 +252,8 @@ describe('<Security />', () => {
         isPending: false
       };
       const mockProps = {
-        oktaAuth
+        oktaAuth,
+        restoreOriginalUri
       };
       const wrapper = mount(
         <Security {...mockProps}>
@@ -247,7 +268,8 @@ describe('<Security />', () => {
         isPending: true
       };
       const mockProps = {
-        oktaAuth
+        oktaAuth,
+        restoreOriginalUri
       };
       const wrapper = mount(
         <Security {...mockProps}>
@@ -258,12 +280,29 @@ describe('<Security />', () => {
     });
 
     it('should render error if oktaAuth props is not provided', () => {
+      const mockProps = {
+        oktaAuth: null,
+        restoreOriginalUri
+      };
       const wrapper = mount(
-        <Security oktaAuth={null}>
+        <Security {...mockProps}>
           <MyComponent />
         </Security>
       );
       expect(wrapper.find(Security).html()).toBe('<p>AuthSdkError: No oktaAuth instance passed to Security Component.</p>');
+    });
+
+    it('should render error if restoreOriginalUri prop is not provided', () => {
+      const mockProps = {
+        oktaAuth,
+        restoreOriginalUri: null
+      };
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <MyComponent />
+        </Security>
+      );
+      expect(wrapper.find(Security).html()).toBe('<p>AuthSdkError: No restoreOriginalUri callback passed to Security Component.</p>');
     });
   });
 });

--- a/test/jest/security.test.tsx
+++ b/test/jest/security.test.tsx
@@ -45,15 +45,6 @@ describe('<Security />', () => {
     expect(oktaAuth.userAgent).toEqual(`${pkg.name}/${pkg.version} okta/okta-auth-js`);
   });
 
-  it('should set default restoreOriginalUri callback in oktaAuth.options', () => {
-    oktaAuth.options = {};
-    const mockProps = {
-      oktaAuth
-    };
-    mount(<Security {...mockProps} />);
-    expect(oktaAuth.options.restoreOriginalUri).toBeDefined();
-  });
-
   it('gets initial state from oktaAuth and exposes it on the context', () => {
     const mockProps = {
       oktaAuth


### PR DESCRIPTION
Internal ref: https://oktainc.atlassian.net/browse/OKTA-333775
Resolves: https://github.com/okta/okta-oidc-js/issues/910

### Changes:
- Added required prop `restoreOriginalUri` to `Security`
- Updated readme with setting `restoreOriginalUri` callback for `react-router`