### PR TITLE
Fix function based login button example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ export default withOktaAuth(class Home extends Component {
 const Home = () => {
   const { oktaAuth, authState } = useOktaAuth();
 
-  const login = async () => oktaAuth.signInWithRedirect('/');
+  const login = async () => oktaAuth.signInWithRedirect();
   const logout = async () => oktaAuth.signOut('/');
 
   if(authState.isPending) {


### PR DESCRIPTION
`'/'` is not a correct argument for `signInWithRedirect` method.
Adjusted to same args (empty) as a class based example.

Btw. I think docs here
https://developer.okta.com/docs/guides/sign-into-spa/react/add-signin-button/
Should be updated as well.