### PR TITLE
Decouple from react-router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Breaking Changes
 
 - [#71](https://github.com/okta/okta-react/pull/71) Adds required prop `restoreOriginalUri` to `Security` that will override `restoreOriginalUri` callback of `oktaAuth`
+- [#74](https://github.com/okta/okta-react/pull/74) `SecureRoute` is not exported to `@okta/okta-react`. Use `import SecureRoute from '@okta/okta-react/lib/SecureRoute'`
+- [#74](https://github.com/okta/okta-react/pull/74) Use ES6 modules as main entry point instead of rollup bundle
 
 # 4.1.1
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ This example defines 3 routes:
 
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Route, withRouter } from 'react-router-dom';
-import { SecureRoute, Security, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import SecureRoute from '@okta/okta-react/lib/SecureRoute';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import Home from './Home';
 import Protected from './Protected';
@@ -163,7 +164,8 @@ export default class extends Component {
 
 ```jsx
 import React from 'react';
-import { SecureRoute, Security, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import SecureRoute from '@okta/okta-react/lib/SecureRoute';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import { useHistory } from 'react-router-dom';
 import Home from './Home';
@@ -431,7 +433,6 @@ class App extends Component {
     );
   }
 }
-
 ```
 
 ### `SecureRoute`
@@ -441,6 +442,11 @@ class App extends Component {
 `SecureRoute` accepts `onAuthRequired` as an optional prop, it overrides [onAuthRequired](#onauthrequired) from the [Security](#security) component if exists.
   
 `SecureRoute` integrates with `react-router`.  Other routers will need their own methods to ensure authentication using the hooks/HOC props provided by this SDK.
+
+From veriosn 5.0 you need to import `SecureRoute` as follows:
+```jsx
+import SecureRoute from '@okta/okta-react/lib/SecureRoute';
+```
 
 As with `Route` from `react-router-dom`, `<SecureRoute>` can take one of:
 
@@ -482,6 +488,8 @@ export default MyComponent = () => {
 
 ### Migrating from 4.x to 5.x
 
+#### Updating the Security component
+
 From version 5.0, the Security component explicitly requires prop [restoreOriginalUri](#restoreoriginaluri) to decouple from `react-router`. 
 Example of implementation of this callback for `react-router`:
 
@@ -511,6 +519,13 @@ export default App = () => {
     </Security>
   );
 };
+```
+
+#### New location for import
+
+`SecureRoute` can't be imported from `@okta/okta-react`. You need to import `SecureRoute` as follows:
+```jsx
+import SecureRoute from '@okta/okta-react/lib/SecureRoute';
 ```
 
 ### Migrating from 3.x to 4.x

--- a/build.js
+++ b/build.js
@@ -7,6 +7,9 @@ const fs = require('fs');
 const NPM_DIR = `dist`;
 const BUNDLE_CMD = 'yarn bundle';
 const BANNER_CMD = `yarn banners`;
+const TSC_CMD = 'tsc';
+const TYPES_DIR = `${NPM_DIR}/types`;
+const SRC_DIR = `${NPM_DIR}/lib`;
 
 shell.echo(`Start building...`);
 
@@ -17,6 +20,13 @@ if (shell.exec(BUNDLE_CMD).code !== 0) {
   shell.echo(chalk.red(`Error: Rollup failed`));
   shell.exit(1);
 }
+
+// Compile ES6 modules
+if (shell.exec(TSC_CMD).code !== 0) {
+  shell.echo(chalk.red(`Error: Compiling ES6 modules failed`));
+  shell.exit(1);
+}
+shell.cp(`-Rf`, `${TYPES_DIR}/*`, SRC_DIR);
 
 // Maintain banners
 if (shell.exec(BANNER_CMD).code !== 0) {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,8 @@
   "keywords": [
     "oauth2"
   ],
-  "main": "dist/bundles/okta-react.cjs.js",
-  "module": "dist/bundles/okta-react.esm.js",
-  "types": "dist/bundles/types",
+  "main": "dist/lib",
+  "types": "dist/types",
   "author": "",
   "license": "Apache-2.0",
   "bugs": {

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -5,5 +5,8 @@ if [ "${TRAVIS_EVENT_TYPE}" = "cron" ] ; then
     yarn test:e2e
 else
     # run the lint, unit and e2e tests (on chrome headless)
+    rm -f ./node_modules/@okta/okta-react
+    mkdir ./node_modules/@okta/okta-react
+    cp -r ./dist/* ./node_modules/@okta/okta-react/
     yarn test
 fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import Security from './Security';
 import withOktaAuth from './withOktaAuth';
 import OktaContext, { useOktaAuth } from './OktaContext';
 import LoginCallback from './LoginCallback';
-import SecureRoute from './SecureRoute';
 
 export {
   Security,
@@ -22,5 +21,4 @@ export {
   useOktaAuth,
   OktaContext,
   LoginCallback,
-  SecureRoute,
 };

--- a/test/e2e/harness/src/App.tsx
+++ b/test/e2e/harness/src/App.tsx
@@ -13,7 +13,8 @@
 import * as React from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
-import { Security, LoginCallback, SecureRoute } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import SecureRoute from '@okta/okta-react/lib/SecureRoute';
 import Home from './Home';
 import Protected from './Protected';
 import CustomLogin from './CustomLogin';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "declarationDir": "dist/bundles/types",
+    "declarationDir": "dist/types",
     "target": "ES2019",
-    "sourceMap": true,
+    "outDir": "dist/lib",
+    "sourceMap": false,
     "jsx": "react",
     "moduleResolution": "node",
     "strictFunctionTypes": true,


### PR DESCRIPTION
Internal ref: https://oktainc.atlassian.net/browse/OKTA-333775
Resolves: https://github.com/okta/okta-oidc-js/issues/910

It's 2nd part of decoupling from `react-router`. 1st is https://github.com/okta/okta-react/pull/71

### Breaking Changes

- `SecureRoute` is not exported to `@okta/okta-react`. Use `import SecureRoute from '@okta/okta-react/lib/SecureRoute'`
- Use ES6 modules as main entry point instead of rollup bundle


#### Discussion
- Maybe move modules from `lib` folder to root of `dist`?
 
#### Motivation
If user doesn't want to use `react-router` but uses [`@reach/router`](https://reach.tech/router/) instead and doesn't install `react-router-dom` as dependency, there will be error :
```
index.js:66 Uncaught Error: Cannot find module 'react-router-dom'
    at webpackMissingModule (index.js:66)
    at Module../node_modules/@okta/okta-react/bundles/okta-react.esm.js (index.js:66)
    at __webpack_require__ (bootstrap:851)

index.js:1 ./node_modules/@okta/okta-react/bundles/okta-react.esm.js
Module not found: Can't resolve 'react-router-dom' in 'samples-js-react/okta-hosted-login/node_modules/@okta/okta-react/bundles'
```