### PR TITLE
Fix dev-5.0 conflicts

### DIFF
--- a/test/jest/security.test.tsx
+++ b/test/jest/security.test.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter, Router } from 'react-router-dom';
+import { toRelativeUrl } from '@okta/okta-auth-js';
 import { createBrowserHistory } from 'history';
 import Security from '../../src/Security';
 import { useOktaAuth } from '../../src/OktaContext';
@@ -351,9 +352,17 @@ describe('<Security />', () => {
     });
 
     const renderRouterWithSecurity = function (history) {
+      const mockProps = {
+        oktaAuth,
+        restoreOriginalUri: async (_, originalUri) => {
+          const basepath = history.createHref({});
+          const originalUriWithoutBasepath = originalUri.replace(basepath, '/');
+          history.replace(toRelativeUrl(originalUriWithoutBasepath, window.location.origin));
+        }
+      };
       mount(
         <Router history={history}>
-          <Security oktaAuth={oktaAuth}>
+          <Security {...mockProps}>
             <></>
           </Security>
         </Router>

--- a/test/jest/security.test.tsx
+++ b/test/jest/security.test.tsx
@@ -13,9 +13,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { MemoryRouter, Router } from 'react-router-dom';
-import { toRelativeUrl } from '@okta/okta-auth-js';
-import { createBrowserHistory } from 'history';
+import { MemoryRouter } from 'react-router-dom';
 import Security from '../../src/Security';
 import { useOktaAuth } from '../../src/OktaContext';
 import * as pkg from '../../package.json';
@@ -306,67 +304,5 @@ describe('<Security />', () => {
       );
       expect(wrapper.find(Security).html()).toBe('<p>AuthSdkError: No restoreOriginalUri callback passed to Security Component.</p>');
     });
-  });
-
-  describe('basename logic in default restoreOriginalUri implementation', () => {
-    it('removes basename from original URI before navigating', async () => {
-      const history = createBrowserHistory({
-        basename: '/basename'
-      });
-      const navigateSpy = jest.spyOn(history, 'replace');
-
-      renderRouterWithSecurity(history);
-      await oktaAuth.options.restoreOriginalUri(null, 'http://localhost/basename/profile?queryParam=1');
-      expect(navigateSpy).toBeCalledWith('/profile?queryParam=1');
-    });
-
-    it('handles nested basename path', async () => {
-      const history = createBrowserHistory({
-        basename: '/siteRoot/app1'
-      });
-      const navigateSpy = jest.spyOn(history, 'replace');
-
-      renderRouterWithSecurity(history);
-      await oktaAuth.options.restoreOriginalUri(null, 'http://localhost/siteRoot/app1/profile#anchor');
-      expect(navigateSpy).toBeCalledWith('/profile#anchor');
-    });
-
-    it("handles Router configuration with baseanme set to '/'", async () => {
-      const history = createBrowserHistory({
-        basename: '/'
-      });
-      const navigateSpy = jest.spyOn(history, 'replace');
-
-      renderRouterWithSecurity(history);
-      await oktaAuth.options.restoreOriginalUri(null, 'http://localhost/profile?queryParam=1');
-      expect(navigateSpy).toBeCalledWith('/profile?queryParam=1');
-    });
-
-    it('handles Router configuration without basename property set', async () => {
-      const history = createBrowserHistory({});
-      const navigateSpy = jest.spyOn(history, 'replace');
-
-      renderRouterWithSecurity(history);
-      await oktaAuth.options.restoreOriginalUri(null, 'http://localhost/profile?queryParam=1');
-      expect(navigateSpy).toBeCalledWith('/profile?queryParam=1');
-    });
-
-    const renderRouterWithSecurity = function (history) {
-      const mockProps = {
-        oktaAuth,
-        restoreOriginalUri: async (_, originalUri) => {
-          const basepath = history.createHref({});
-          const originalUriWithoutBasepath = originalUri.replace(basepath, '/');
-          history.replace(toRelativeUrl(originalUriWithoutBasepath, window.location.origin));
-        }
-      };
-      mount(
-        <Router history={history}>
-          <Security {...mockProps}>
-            <></>
-          </Security>
-        </Router>
-      );
-    };
   });
 });


### PR DESCRIPTION
As we don't have a default implementation for `restoreOriginalUri` in `Security` in 5.0, removed obsolete tests