### PR TITLE
interaction required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.1.0
+
+### Features
+- [#104](https://github.com/okta/okta-react/pull/104) Adds support for `onAuthResume` to `LoginCallback` for `interaction_required` OAuth errors (requires okta-auth-js 4.8+)
+
 # 5.0.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -476,6 +476,36 @@ As with `Route` from `react-router-dom`, `<SecureRoute>` can take one of:
 
 `LoginCallback` handles the callback after the redirect to and back from the Okta-hosted login page. By default, it parses the tokens from the uri, stores them, then redirects to `/`. If a `SecureRoute` caused the redirect, then the callback redirects to the secured route. For more advanced cases, this component can be copied to your own source tree and modified as needed.
 
+#### errorComponent
+
+By default, LoginCallback will display any errors from `authState.error`.  If you wish to customise the display of such error messages, you can pass your own component as an `errorComponent` prop to `<LoginCallback>`.  The `authState.error` value will be passed to the `errorComponent` as the `error` prop.
+
+#### onAuthResume
+
+In special cases where an external auth (such as a social IDP) redirects back to your application AND your Okta sign-in policies require additional authentication factors before authentication is complete, the redirect to your application redirectUri callback will be an `interaction_required` error.  Such an error can be handled like any other error, or you can pass an `onAuthResume` function as a prop to `<LoginCallback>`.  `onAuthResume` is expected to handle the `interaction_required`.  Most commonly (for this not-common situation) you will want your application to resume the login.  If using the Okta SignIn Widget, redirecting to your login route will allow the widget to automatically resume your authentication transaction.
+
+```jsx
+// Example assumes you are using react-router and a customer-hosted Okta SignIn Widget
+// This is wherever you have your <Security> component, which must be inside your <Router> for react-router
+  const onAuthResume = async () => { 
+    history.push('/login');
+  };
+
+return (
+  <Security
+    oktaAuth={oktaAuth}
+    restoreOriginalUri={restoreOriginalUri}
+  >
+    <Switch>
+      <SecureRoute path='/protected' component={Protected} />
+      <Route path='/login/callback' render={ (props) => <LoginCallback {...props} onAuthResume={ onAuthResume } /> } />
+      <Route path='/login' component={CustomLogin} />
+      <Route path='/' component={Home} />
+    </Switch>
+  </Security>
+);
+```
+
 ### `withOktaAuth`
 
 `withOktaAuth` is a [higher-order component][] which injects an [oktaAuth][Okta Auth SDK] instance and an [authState][AuthState] object as props into the component. Function-based components will want to use the `useOktaAuth` hook instead.  These props provide a way for components to make decisions based on [authState][AuthState] or to call [Okta Auth SDK][] methods, such as `.signInWithRedirect()` or `.signOut()`.  Components wrapped in `withOktaAuth()` need to be a child or descendant of a `<Security>` component to have the necessary context.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [Okta Auth SDK]: https://github.com/okta/okta-auth-js
+[Okta SignIn Widget]: https://github.com/okta/okta-signin-widget
 [AuthState]: https://github.com/okta/okta-auth-js#authstatemanager
 [react-router]: https://github.com/ReactTraining/react-router
 [reach-router]: https://reach.tech/router
@@ -482,11 +483,15 @@ By default, LoginCallback will display any errors from `authState.error`.  If yo
 
 #### onAuthResume
 
-In special cases where an external auth (such as a social IDP) redirects back to your application AND your Okta sign-in policies require additional authentication factors before authentication is complete, the redirect to your application redirectUri callback will be an `interaction_required` error.  Such an error can be handled like any other error, or you can pass an `onAuthResume` function as a prop to `<LoginCallback>`.  `onAuthResume` is expected to handle the `interaction_required`.  Most commonly (for this not-common situation) you will want your application to resume the login.  If using the Okta SignIn Widget, redirecting to your login route will allow the widget to automatically resume your authentication transaction.
+When an external auth (such as a social IDP) redirects back to your application AND your Okta sign-in policies require additional authentication factors before authentication is complete, the redirect to your application redirectUri callback will be an `interaction_required` error.  
+
+An `interaction_required` error is an indication that you should resume the authentication flow.  You can pass an `onAuthResume` function as a prop to `<LoginCallback>`, and the `<LoginCallback>` will call the `onAuthResume` function when an `interaction_required` error is returned to the redirectUri of your application.  
+
+If using the [Okta SignIn Widget][], redirecting to your login route will allow the widget to automatically resume your authentication transaction.
 
 ```jsx
-// Example assumes you are using react-router and a customer-hosted Okta SignIn Widget
-// This is wherever you have your <Security> component, which must be inside your <Router> for react-router
+// Example assumes you are using react-router with a customer-hosted Okta SignIn Widget on your /login route
+// This code is wherever you have your <Security> component, which must be inside your <Router> for react-router
   const onAuthResume = async () => { 
     history.push('/login');
   };

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "yarn": "^1.7.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.11.2"
+    "@babel/runtime": "^7.11.2",
+    "@okta/okta-auth-js": "^4.8.0"
   },
   "peerDependencies": {
-    "@okta/okta-auth-js": "^4.1.0",
     "@types/react-router-dom": "^5.1.6",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
@@ -57,7 +57,6 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.12.1",
-    "@okta/okta-auth-js": "^4.1.2",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-replace": "^2.3.4",
     "@types/enzyme": "^3.10.8",

--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -11,19 +11,28 @@
  */
 
 import * as React from 'react';
-import { useOktaAuth } from './OktaContext';
+import { useOktaAuth, OnAuthResumeFunction } from './OktaContext';
 import OktaError from './OktaError';
 
 const LoginCallback: React.FC<{ 
-  errorComponent?: React.ComponentType<{ error: Error }>
-}> = ({ errorComponent }) => { 
+  errorComponent?: React.ComponentType<{ error: Error }>,
+  onAuthResume?: OnAuthResumeFunction,
+}> = ({ errorComponent, onAuthResume }) => { 
   const { oktaAuth, authState } = useOktaAuth();
   const authStateReady = !authState.isPending;
-
   const ErrorReporter = errorComponent || OktaError;
 
   React.useEffect(() => {
-    oktaAuth.handleLoginRedirect();
+
+    if (onAuthResume && oktaAuth.isInteractionRequired?.() ) {
+      onAuthResume();
+      return;
+    }
+    oktaAuth.handleLoginRedirect()
+    .catch( err => { 
+      console.log(err); //TODO: handle these errors OKTA-361608
+    });  
+
   }, [oktaAuth]);
 
   if(authStateReady && authState.error) { 

--- a/src/OktaContext.ts
+++ b/src/OktaContext.ts
@@ -13,6 +13,7 @@ import * as React from 'react';
 import { AuthState, OktaAuth } from '@okta/okta-auth-js';
 
 export type OnAuthRequiredFunction = (oktaAuth: OktaAuth) => Promise<void> | void;
+export type OnAuthResumeFunction = () => void;
 
 export type RestoreOriginalUriFunction = (oktaAuth: OktaAuth, originalUri: string) => Promise<void> | void;
 

--- a/src/SecureRoute.tsx
+++ b/src/SecureRoute.tsx
@@ -51,14 +51,11 @@ const SecureRoute: React.FC<{
       return;
     }
 
-    try { 
     // Start login if app has decided it is not logged in and there is no pending signin
     if(!authState.isAuthenticated && !authState.isPending) { 
       handleLogin();
     }  
-  } catch (err) { 
-    console.log(err);
-  }
+
   }, [
     authState.isPending, 
     authState.isAuthenticated, 

--- a/src/SecureRoute.tsx
+++ b/src/SecureRoute.tsx
@@ -51,10 +51,14 @@ const SecureRoute: React.FC<{
       return;
     }
 
+    try { 
     // Start login if app has decided it is not logged in and there is no pending signin
     if(!authState.isAuthenticated && !authState.isPending) { 
       handleLogin();
     }  
+  } catch (err) { 
+    console.log(err);
+  }
   }, [
     authState.isPending, 
     authState.isAuthenticated, 

--- a/test/e2e/harness/package.json
+++ b/test/e2e/harness/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.8",
   "private": true,
   "dependencies": {
-    "@okta/okta-auth-js": "^4.1.2",
+    "@okta/okta-auth-js": "^4.8.0",
     "@okta/okta-react": "*",
     "@types/node": "^14.14.7",
     "@types/react": "^16.9.56",

--- a/test/e2e/harness/public/index.html
+++ b/test/e2e/harness/public/index.html
@@ -20,6 +20,8 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script src="https://global.oktacdn.com/okta-signin-widget/5.4.0/js/okta-sign-in.min.js" type="text/javascript"></script>
+    <link href="https://global.oktacdn.com/okta-signin-widget/5.4.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
   </head>
   <body>
     <noscript>

--- a/test/e2e/harness/src/App.tsx
+++ b/test/e2e/harness/src/App.tsx
@@ -17,16 +17,22 @@ import { Security, LoginCallback, SecureRoute } from '@okta/okta-react';
 import Home from './Home';
 import Protected from './Protected';
 import CustomLogin from './CustomLogin';
+import WidgetLogin from './WidgetLogin';
 import SessionTokenLogin from './SessionTokenLogin';
 
 const App: React.FC<{ 
   oktaAuth: OktaAuth, 
-  customLogin: boolean 
-}> = ({ oktaAuth, customLogin }) => {
+  customLogin: boolean, 
+  baseUrl: string,
+}> = ({ oktaAuth, customLogin, baseUrl }) => {
   const history = useHistory();
 
   const onAuthRequired = async () => {
     history.push('/login');
+  };
+
+  const onAuthResume = async () => { 
+    history.push('/widget-login');
   };
 
   const restoreOriginalUri = async (_oktaAuth: OktaAuth, originalUri: string) => {
@@ -41,12 +47,13 @@ const App: React.FC<{
         restoreOriginalUri={restoreOriginalUri}
       >
         <Switch>
-          <Route path='/login' component={CustomLogin}/>
-          <Route path='/sessionToken-login' component={SessionTokenLogin}/>
-          <SecureRoute exact path='/protected' component={Protected}/>
+          <Route path='/login' component={CustomLogin} />
+          <Route path='/widget-login' render={ (props) => <WidgetLogin {...props} baseUrl={baseUrl} /> }/>
+          <Route path='/sessionToken-login' component={SessionTokenLogin} />
+          <SecureRoute exact path='/protected' component={Protected} />
           <Route path='/implicit/callback' component={LoginCallback} />
-          <Route path='/pkce/callback' component={LoginCallback} />
-          <Route path='/' component={Home}/>
+          <Route path='/pkce/callback' render={ (props) => <LoginCallback {...props} onAuthResume={ onAuthResume } /> } />
+          <Route path='/' component={Home} />
         </Switch>
       </Security>
       <a href="/?pkce=1">PKCE Flow</a> | <a href="/">Implicit Flow</a>

--- a/test/e2e/harness/src/Home.tsx
+++ b/test/e2e/harness/src/Home.tsx
@@ -44,6 +44,7 @@ const Home: React.FC = () => {
       <Link to='/'>Home</Link><br/>
       <Link to='/protected'>Protected</Link><br/>
       <Link to='/sessionToken-login'>Session Token Login</Link><br/>
+      <Link to='/widget-login'>Widget Login</Link><br/>
       {button}
       { authState.isAuthenticated ? <button id="renew-id-token-button" onClick={renewToken('idToken')}>Renew ID Token</button> : null }
       { authState.isAuthenticated ? <button id="renew-access-token-button" onClick={renewToken('accessToken')}>Renew Access Token</button> : null }

--- a/test/e2e/harness/src/WidgetLogin.tsx
+++ b/test/e2e/harness/src/WidgetLogin.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+import * as React from 'react';
+import { useOktaAuth } from '@okta/okta-react';
+
+declare global {
+  // TODO: Remove "any"s once widget has TS definitions
+  interface Window { OktaSignIn: any } // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+const WidgetLogin: React.FC<{
+  baseUrl: string,
+}> = (baseUrl) => {
+  const { oktaAuth } = useOktaAuth();
+  const widgetRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect( () => {
+    if (!widgetRef.current) {
+      return;
+    }
+
+    const widget = new window.OktaSignIn({
+      baseUrl,
+      authClient: oktaAuth, // Note: the interactionCodeFlow below requires PKCE enabled on the authClient 
+      useInteractionCodeFlow: true, // Set to true, if your org is OIE enabled
+    });
+
+    widget.on('afterError', (context: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+      console.log({ context });
+      // The Widget is ready for user input
+    });
+
+    widget.renderEl(
+      { el: widgetRef.current },
+      (res: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+        console.log(res);
+        oktaAuth.handleLoginRedirect(res.tokens);
+      },
+      (err: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+        console.log({ err });  
+        throw err;
+      },
+    );
+
+    return () => widget.remove();
+  }, [oktaAuth, baseUrl]);
+
+  return (
+    <div>
+      <p>Note: Requires interaction code flow and PKCE</p>
+      <div ref={widgetRef} />
+    </div>
+  );
+};
+export default WidgetLogin;

--- a/test/e2e/harness/src/index.tsx
+++ b/test/e2e/harness/src/index.tsx
@@ -26,6 +26,7 @@ const url = new URL(window.location.href);
 const pkce = !!url.searchParams.get('pkce') || url.pathname.indexOf('pkce/callback') >= 0;
 const redirectUri = window.location.origin + (pkce ? '/pkce/callback' : '/implicit/callback');
 const customLogin = !!url.searchParams.get('customLogin');
+const baseUrl =  ISSUER?.split('/oauth2')[0] || 'ISSUER-NOT-SUPPLIED';
 
 const oktaAuth = new OktaAuth({
   issuer: ISSUER,
@@ -36,7 +37,7 @@ const oktaAuth = new OktaAuth({
 
 ReactDOM.render(
   <Router>
-    <App oktaAuth={oktaAuth} customLogin={customLogin} />
+    <App oktaAuth={oktaAuth} customLogin={customLogin} baseUrl={baseUrl} />
   </Router>
   , document.getElementById('root')
 );

--- a/test/jest/loginCallback.test.tsx
+++ b/test/jest/loginCallback.test.tsx
@@ -123,6 +123,7 @@ describe('<LoginCallback />', () => {
         </Security>
       );
       expect(resumeFunction).not.toHaveBeenCalled();
+      expect(wrapper.text()).toBe('');
     });
 
     it('will trigger a passed onAuthResume function when isInteractionRequired is true', () => {
@@ -137,7 +138,7 @@ describe('<LoginCallback />', () => {
       expect(wrapper.text()).toBe(''); // no output since we expect to be redirected
     });
 
-    it('will treat isInteractionRequired like a normal error if not onAuthResume is passed ', () => { 
+    it('will treat isInteractionRequired like a normal error if not onAuthResume is passed', () => { 
       oktaAuth.isInteractionRequired = jest.fn().mockImplementation( () => true );
       const wrapper = mount(
         <Security {...mockProps}>

--- a/test/jest/loginCallback.test.tsx
+++ b/test/jest/loginCallback.test.tsx
@@ -34,7 +34,8 @@ describe('<LoginCallback />', () => {
         updateAuthState: jest.fn(),
       },
       isLoginRedirect: jest.fn().mockImplementation(() => false),
-      handleLoginRedirect: jest.fn()
+      isInteractionRequired: jest.fn().mockImplementation( () => false ),
+      handleLoginRedirect: jest.fn().mockImplementation( () => Promise.resolve() ),
     };
     mockProps = {
       oktaAuth, 
@@ -112,6 +113,38 @@ describe('<LoginCallback />', () => {
         </Security>
       );
       expect(wrapper.text()).toBe('Override: errorData');
+    });
+
+    it('will not trigger a passed onAuthResume when isInteractionRequired is false', () => { 
+      const resumeFunction = jest.fn();
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <LoginCallback onAuthResume={resumeFunction}/>
+        </Security>
+      );
+      expect(resumeFunction).not.toHaveBeenCalled();
+    });
+
+    it('will trigger a passed onAuthResume function when isInteractionRequired is true', () => {
+      oktaAuth.isInteractionRequired = jest.fn().mockImplementation( () => true );
+      const resumeFunction = jest.fn();
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <LoginCallback onAuthResume={resumeFunction}/>
+        </Security>
+      );
+      expect(resumeFunction).toHaveBeenCalled();
+      expect(wrapper.text()).toBe(''); // no output since we expect to be redirected
+    });
+
+    it('will treat isInteractionRequired like a normal error if not onAuthResume is passed ', () => { 
+      oktaAuth.isInteractionRequired = jest.fn().mockImplementation( () => true );
+      const wrapper = mount(
+        <Security {...mockProps}>
+          <LoginCallback />
+        </Security>
+      );
+      expect(wrapper.text()).toBe(''); // TODO: should be noticed as an error OKTA-361608
     });
 
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,6 +1173,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
@@ -1663,16 +1670,18 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@okta/okta-auth-js@^4.1.2":
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.6.1.tgz#b82cfa72216aeab452dbea7a4c27c8603200a071"
-  integrity sha512-D7RRI356IAoKORDuxfK6Kd9ipoZxPYNlWkR1N0UhTMHOhsQ8PSfjCQy4z/pYCnD6AtaZRbjq0KQfTQrzIq2+rA==
+"@okta/okta-auth-js@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.8.0.tgz#b745bc826b0df16f51f481a07a89f3387d48ab45"
+  integrity sha512-uaF2jS6avN0BNJ8EuJYM+KIwm3KZRo4QNAnEUDppysnxRtPlgExU2ndMEPZoSyYbCRdEd1x8UuSWTxrXhXThKQ==
   dependencies:
-    Base64 "0.3.0"
+    "@babel/runtime" "^7.12.5"
+    Base64 "1.1.0"
     core-js "^3.6.5"
-    cross-fetch "^3.0.0"
-    js-cookie "2.2.0"
-    node-cache "^4.2.0"
+    cross-fetch "^3.0.6"
+    js-cookie "2.2.1"
+    karma-coverage "^2.0.3"
+    node-cache "^5.1.2"
     p-cancelable "^2.0.0"
     text-encoding "^0.7.0"
     tiny-emitter "1.1.0"
@@ -2480,10 +2489,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-Base64@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.3.0.tgz#6da261a4e80d4fa0f5c684254e5bccd16bbdce9f"
-  integrity sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8=
+Base64@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.1.0.tgz#810ef21afa8357df92ad7b5389188c446b9cb956"
+  integrity sha512-qeacf8dvGpf+XAT27ESHMh7z84uRzj/ua2pQdJg483m3bEXv/kVFtDnMgvf70BQGqzbZhR9t6BmASzKvqfJf3Q==
 
 abab@^2.0.0, abab@^2.0.3:
   version "2.0.5"
@@ -4176,10 +4185,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.0:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
-  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+cross-fetch@^3.0.6:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.3.tgz#b8e7d5f19161c4a0ca916f707978848786043afb"
+  integrity sha512-2i6v88DTqVBNODyjD9U6Ycn/uSZNvyHe25cIbo2fFnAACAsaLTJsd23miRWiR5NuiGXR9wpJ9d40/9WAhjDIrw==
   dependencies:
     node-fetch "2.6.1"
 
@@ -7390,7 +7399,7 @@ istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
     istanbul-lib-coverage "^2.0.5"
     semver "^6.0.0"
 
-istanbul-lib-instrument@^4.0.0, istanbul-lib-instrument@^4.0.3:
+istanbul-lib-instrument@^4.0.0, istanbul-lib-instrument@^4.0.1, istanbul-lib-instrument@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
   integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
@@ -7445,7 +7454,7 @@ istanbul-reports@^2.2.6:
   dependencies:
     html-escaper "^2.0.0"
 
-istanbul-reports@^3.0.2:
+istanbul-reports@^3.0.0, istanbul-reports@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
   integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
@@ -8289,10 +8298,10 @@ js-cleanup@^1.2.0:
     perf-regexes "^1.0.1"
     skip-regex "^1.0.2"
 
-js-cookie@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
-  integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
+js-cookie@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -8531,6 +8540,18 @@ jszip@^3.1.3:
     pako "~1.0.2"
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
+
+karma-coverage@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/karma-coverage/-/karma-coverage-2.0.3.tgz#c10f4711f4cf5caaaa668b1d6f642e7da122d973"
+  integrity sha512-atDvLQqvPcLxhED0cmXYdsPMCQuh6Asa9FMZW1bhNqlVEhJoB9qyZ2BY1gu7D/rr5GLGb5QzYO4siQskxaWP/g==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.1"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.0"
+    minimatch "^3.0.4"
 
 keypress@^0.2.1:
   version "0.2.1"
@@ -9262,13 +9283,12 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-cache@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.1.tgz#efd8474dee4edec4138cdded580f5516500f7334"
-  integrity sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
   dependencies:
     clone "2.x"
-    lodash "^4.17.15"
 
 node-environment-flags@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
This adds the option to pass an `onAuthResume` function param to `<LoginCallback>`, which will be called when the callback gets an `interaction_required` error redirect.  

The callback will most often redirect to the login path to resume the login (in particular if using the widget, which will automatically resume).

