### PR TITLE
readme: Use '/' if originalUri is null in restoreOriginalUri

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ class App extends Component {
       redirectUri: window.location.origin + '/login/callback'
     });
     this.restoreOriginalUri = async (_oktaAuth, originalUri) => {
-      props.history.replace(toRelativeUrl(originalUri, window.location.origin));
+      props.history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
     };
   }
 
@@ -204,7 +204,7 @@ const oktaAuth = new OktaAuth({
 const App = () => {
   const history = useHistory();
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
-    history.replace(toRelativeUrl(originalUri, window.location.origin));
+    history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
 
   return (
@@ -417,7 +417,7 @@ export default App = () => {
   };
 
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
-    history.replace(toRelativeUrl(originalUri, window.location.origin));
+    history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
 
   return (


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
In `@okta/okta-auth-js 5.x` default value for originalUri is null. 
This readme change reflects this in recommended implementation of `restoreOriginalUri`.

## Reviewers

