### PR TITLE
[copy] fix: Only unsubscribe the handler subscribed by <Security />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.0.1
+
+### Bug Fixes
+
+- [#112](https://github.com/okta/okta-react/pull/112) Only unsubscribe the `AuthStateManager` handler subscribed by `<Security />`
+
 # 6.0.0
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-react",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "React support for Okta",
   "private": true,
   "scripts": {

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -54,9 +54,10 @@ const Security: React.FC<{
     oktaAuth.userAgent = `${process.env.PACKAGE_NAME}/${process.env.PACKAGE_VERSION} ${oktaAuth.userAgent}`;
 
     // Update Security provider with latest authState
-    oktaAuth.authStateManager.subscribe((authState) => {
+    const handler = (authState) => {
       setAuthState(authState);
-    });
+    };
+    oktaAuth.authStateManager.subscribe(handler);
 
     // Trigger an initial change event to make sure authState is latest
     if (!oktaAuth.isLoginRedirect()) {
@@ -66,7 +67,7 @@ const Security: React.FC<{
     }
 
     return () => {
-      oktaAuth.authStateManager.unsubscribe();
+      oktaAuth.authStateManager.unsubscribe(handler);
       oktaAuth.stop();
     };
   }, [oktaAuth, restoreOriginalUri]);

--- a/test/jest/security.test.tsx
+++ b/test/jest/security.test.tsx
@@ -34,9 +34,11 @@ describe('<Security />', () => {
       authStateManager: {
         getAuthState: jest.fn().mockImplementation(() => initialAuthState),
         subscribe: jest.fn(),
+        unsubscribe: jest.fn(),
       },
       isLoginRedirect: jest.fn().mockImplementation(() => false),
       start: jest.fn(),
+      stop: jest.fn(),
     };
   });
 
@@ -147,18 +149,28 @@ describe('<Security />', () => {
         fromEventDispatch: true
       }
     ];
-    let callback;
+    let callbacks = [];
     let stateCount = 0;
+    callbacks.push(() => {
+      // dummy subscriber that should be preserved after `<Security />` unmount
+    });
     oktaAuth.authStateManager.getAuthState.mockImplementation( () => { 
       return mockAuthStates[stateCount];
     });
     oktaAuth.authStateManager.subscribe.mockImplementation(fn => {
-      callback = fn;
+      callbacks.push(fn);
+    });
+    oktaAuth.authStateManager.unsubscribe.mockImplementation(fn => {
+      const index = callbacks.indexOf(fn);
+      if (index !== -1) {
+        callbacks.splice(index, 1);
+      }
     });
     oktaAuth.start.mockImplementation(() => {
       stateCount++;
-      callback(mockAuthStates[stateCount]);
+      callbacks.map(fn => fn(mockAuthStates[stateCount]));
     });
+    oktaAuth.stop.mockImplementation(() => {});
     const mockProps = {
       oktaAuth,
       restoreOriginalUri
@@ -183,22 +195,27 @@ describe('<Security />', () => {
         return null;
       });
 
-    mount(
+    const component = mount(
       <MemoryRouter>
         <Security {...mockProps}>
           <MyComponent />
         </Security>
       </MemoryRouter>
     );
+    expect(callbacks.length).toEqual(2);
     expect(oktaAuth.authStateManager.subscribe).toHaveBeenCalledTimes(1);
     expect(oktaAuth.start).toHaveBeenCalledTimes(1);
     expect(MyComponent).toHaveBeenCalledTimes(2);
     MyComponent.mockClear();
     act(() => {
       stateCount++;
-      callback(mockAuthStates[stateCount]);
+      callbacks.map(fn => fn(mockAuthStates[stateCount]));
     });
     expect(MyComponent).toHaveBeenCalledTimes(1);
+
+    component.unmount();
+    expect(oktaAuth.stop).toHaveBeenCalledTimes(1);
+    expect(callbacks.length).toEqual(1);
   });
 
   it('should accept a className prop and render a component using the className', () => {

--- a/test/jest/security.test.tsx
+++ b/test/jest/security.test.tsx
@@ -149,7 +149,7 @@ describe('<Security />', () => {
         fromEventDispatch: true
       }
     ];
-    let callbacks = [];
+    const callbacks = [];
     let stateCount = 0;
     callbacks.push(() => {
       // dummy subscriber that should be preserved after `<Security />` unmount
@@ -170,7 +170,6 @@ describe('<Security />', () => {
       stateCount++;
       callbacks.map(fn => fn(mockAuthStates[stateCount]));
     });
-    oktaAuth.stop.mockImplementation(() => {});
     const mockProps = {
       oktaAuth,
       restoreOriginalUri


### PR DESCRIPTION
Copy of https://github.com/okta/okta-react/pull/112