### PR TITLE
Backport 6.0 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.0.1
+
+### Bug Fixes
+
+- [#112](https://github.com/okta/okta-react/pull/112) Only unsubscribe the `AuthStateManager` handler subscribed by `<Security />`
+
 # 6.0.0
 
 ### Breaking Changes

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -54,9 +54,10 @@ const Security: React.FC<{
     oktaAuth.userAgent = `${process.env.PACKAGE_NAME}/${process.env.PACKAGE_VERSION} ${oktaAuth.userAgent}`;
 
     // Update Security provider with latest authState
-    oktaAuth.authStateManager.subscribe((authState) => {
+    const handler = (authState) => {
       setAuthState(authState);
-    });
+    };
+    oktaAuth.authStateManager.subscribe(handler);
 
     // Trigger an initial change event to make sure authState is latest
     if (!oktaAuth.isLoginRedirect()) {
@@ -66,7 +67,7 @@ const Security: React.FC<{
     }
 
     return () => {
-      oktaAuth.authStateManager.unsubscribe();
+      oktaAuth.authStateManager.unsubscribe(handler);
       oktaAuth.stop();
     };
   }, [oktaAuth, restoreOriginalUri]);


### PR DESCRIPTION
- fix: Only unsubscribe the handler subscribed by `<Security />` ([#141](https://github.com/okta/okta-react/pull/141))