### PR TITLE
Fix TS definitions in 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.1.1
+
+### Bug Fixes
+
+- [#146](https://github.com/okta/okta-react/pull/146) Fixed TypeScript definitions
+
 # 6.1.0
 
 ### Features

--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -40,7 +40,7 @@ const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingCo
     });
   }, [oktaAuth]);
 
-  const authError = authStateReady ? authState.error : null;
+  const authError = authStateReady ? authState!.error : null;
   const displayError = callbackError || authError;
   if (displayError) { 
     return <ErrorReporter error={displayError}/>;

--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -24,7 +24,6 @@ const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingCo
   const { oktaAuth, authState } = useOktaAuth();
   const [callbackError, setCallbackError] = React.useState(null);
 
-  const authStateReady = !!authState;
   const ErrorReporter = errorComponent || OktaError;
   React.useEffect(() => {
     if (onAuthResume && oktaAuth.isInteractionRequired?.() ) {
@@ -40,7 +39,7 @@ const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingCo
     });
   }, [oktaAuth]);
 
-  const authError = authStateReady ? authState!.error : null;
+  const authError = authState?.error;
   const displayError = callbackError || authError;
   if (displayError) { 
     return <ErrorReporter error={displayError}/>;

--- a/src/OktaContext.ts
+++ b/src/OktaContext.ts
@@ -19,12 +19,12 @@ export type RestoreOriginalUriFunction = (oktaAuth: OktaAuth, originalUri: strin
 
 export interface IOktaContext {
     oktaAuth: OktaAuth;
-    authState: AuthState;
-    _onAuthRequired: OnAuthRequiredFunction;
+    authState: AuthState | null;
+    _onAuthRequired?: OnAuthRequiredFunction;
 }
 
 const OktaContext = React.createContext<IOktaContext | null>(null);
 
-export const useOktaAuth = (): IOktaContext => React.useContext(OktaContext);
+export const useOktaAuth = (): IOktaContext => React.useContext(OktaContext) as IOktaContext;
 
 export default OktaContext;

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -11,7 +11,7 @@
  */
 
 import * as React from 'react';
-import { AuthSdkError, OktaAuth } from '@okta/okta-auth-js';
+import { AuthSdkError, OktaAuth, AuthState } from '@okta/okta-auth-js';
 import OktaContext, { OnAuthRequiredFunction, RestoreOriginalUriFunction } from './OktaContext';
 import OktaError from './OktaError';
 
@@ -54,7 +54,7 @@ const Security: React.FC<{
     oktaAuth.userAgent = `${process.env.PACKAGE_NAME}/${process.env.PACKAGE_VERSION} ${oktaAuth.userAgent}`;
 
     // Update Security provider with latest authState
-    const handler = (authState) => {
+    const handler = (authState: AuthState) => {
       setAuthState(authState);
     };
     oktaAuth.authStateManager.subscribe(handler);

--- a/src/withOktaAuth.tsx
+++ b/src/withOktaAuth.tsx
@@ -15,8 +15,8 @@ import { useOktaAuth, IOktaContext } from './OktaContext';
 
 const withOktaAuth = <P extends IOktaContext>(
   ComponentToWrap: React.ComponentType<P>
-): React.FC<Omit<P, keyof IOktaContext>> => { 
-  const WrappedComponent = (props) => { 
+) => { 
+  const WrappedComponent = (props: Omit<P, keyof IOktaContext>) => { 
     const oktaAuthProps = useOktaAuth();
     return <ComponentToWrap {...oktaAuthProps as IOktaContext } {...props as P} />;
   };

--- a/src/withOktaAuth.tsx
+++ b/src/withOktaAuth.tsx
@@ -15,7 +15,7 @@ import { useOktaAuth, IOktaContext } from './OktaContext';
 
 const withOktaAuth = <P extends IOktaContext>(
   ComponentToWrap: React.ComponentType<P>
-) => { 
+): React.FC<Omit<P, keyof IOktaContext>> => { 
   const WrappedComponent = (props: Omit<P, keyof IOktaContext>) => { 
     const oktaAuthProps = useOktaAuth();
     return <ComponentToWrap {...oktaAuthProps as IOktaContext } {...props as P} />;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "jsx": "react",
     "moduleResolution": "node",
     "strictFunctionTypes": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true
   },
   "include": ["src/**/*"],
 }


### PR DESCRIPTION
- Fixed TS definitions:   `authState` in `IOktaContext` can be `null` (and some internal definitions)
- Added `"strict": true` to `tsconfig`. This will trigger TS definitions errors on build

(Checked on e2e test app)

Resolves https://github.com/okta/okta-react/issues/140

Internal ref: https://oktainc.atlassian.net/browse/OKTA-409131
