### PR TITLE
feat: onAuthExpired callback

### DIFF
--- a/src/OktaContext.ts
+++ b/src/OktaContext.ts
@@ -14,6 +14,7 @@ import { AuthState, OktaAuth } from '@okta/okta-auth-js';
 
 export type OnAuthRequiredFunction = (oktaAuth: OktaAuth) => Promise<void> | void;
 export type OnAuthResumeFunction = () => void;
+export type OnAuthExpiredFunction = (oktaAuth: OktaAuth) => Promise<void> | void;
 
 export type RestoreOriginalUriFunction = (oktaAuth: OktaAuth, originalUri: string) => Promise<void> | void;
 
@@ -21,6 +22,7 @@ export interface IOktaContext {
     oktaAuth: OktaAuth;
     authState: AuthState | null;
     _onAuthRequired?: OnAuthRequiredFunction;
+    _onAuthExpired?: OnAuthExpiredFunction;
 }
 
 const OktaContext = React.createContext<IOktaContext | null>(null);

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -12,18 +12,20 @@
 
 import * as React from 'react';
 import { AuthSdkError, OktaAuth, AuthState } from '@okta/okta-auth-js';
-import OktaContext, { OnAuthRequiredFunction, RestoreOriginalUriFunction } from './OktaContext';
+import OktaContext, { OnAuthExpiredFunction, OnAuthRequiredFunction, RestoreOriginalUriFunction } from './OktaContext';
 import OktaError from './OktaError';
 
 const Security: React.FC<{
   oktaAuth: OktaAuth,
   restoreOriginalUri: RestoreOriginalUriFunction, 
   onAuthRequired?: OnAuthRequiredFunction,
+  onAuthExpired?: OnAuthExpiredFunction,
   children?: React.ReactNode
 } & React.HTMLAttributes<HTMLDivElement>> = ({ 
   oktaAuth,
   restoreOriginalUri, 
-  onAuthRequired, 
+  onAuthRequired,
+  onAuthExpired,
   children
 }) => { 
   const [authState, setAuthState] = React.useState(() => {
@@ -93,7 +95,8 @@ const Security: React.FC<{
     <OktaContext.Provider value={{ 
       oktaAuth, 
       authState, 
-      _onAuthRequired: onAuthRequired
+      _onAuthRequired: onAuthRequired,
+      _onAuthExpired: onAuthExpired
     }}>
       {children}
     </OktaContext.Provider>

--- a/test/e2e/harness/src/App.tsx
+++ b/test/e2e/harness/src/App.tsx
@@ -35,6 +35,10 @@ const App: React.FC<{
     history.push('/widget-login');
   };
 
+  const onAuthExpired = () => {
+    console.error('onAuthExpired');
+  }
+
   const restoreOriginalUri = async (_oktaAuth: OktaAuth, originalUri: string) => {
     history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
@@ -44,6 +48,7 @@ const App: React.FC<{
       <Security
         oktaAuth={oktaAuth}
         onAuthRequired={customLogin ? onAuthRequired : undefined}
+        onAuthExpired={onAuthExpired}
         restoreOriginalUri={restoreOriginalUri}
       >
         <Switch>

--- a/test/e2e/harness/src/index.tsx
+++ b/test/e2e/harness/src/index.tsx
@@ -32,7 +32,10 @@ const oktaAuth = new OktaAuth({
   issuer: ISSUER,
   clientId: CLIENT_ID,
   redirectUri,
-  pkce
+  pkce,
+  tokenManager: {
+    autoRenew: false
+  }
 });
 
 ReactDOM.render(

--- a/test/e2e/harness/tsconfig.json
+++ b/test/e2e/harness/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "sourceMap": true
   },
   "include": [
     "src"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
onAuthRequired will be called whenever authState.isAuthenticated switches to false. The default behavior is to signin with rerdirect. This causes a redirect after tokens are removed or session expires.

Issue Number: OKTA-394440


## What is the new behavior?
onAuthRequired will only be called once for a SecureRoute. If the use has been authenticated, but then authState.isAuthenticated toggles to false later, a new callback "onAuthExpired" will be called.  


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The secure component's children may be rendered even though `oktaAuth.isAuthenticated()` currently returns false. This could break core assumptions for the child component.


## Other information


## Reviewers

