### PR TITLE
feat: add errorComponent props to SecureRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.3.0
+
+### Features
+
+- [#172](https://github.com/okta/okta-react/pull/172) Adds `errorComponent` prop to `SecureRoute` to handle internal `handleLogin` related errors
+
 # 6.2.0
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -466,7 +466,15 @@ class App extends Component {
 
 `SecureRoute` ensures that a route is only rendered if the user is authenticated. If the user is not authenticated, it calls [onAuthRequired](#onauthrequired) if it exists, otherwise, it redirects to Okta.
 
+#### onAuthRequired
+
 `SecureRoute` accepts `onAuthRequired` as an optional prop, it overrides [onAuthRequired](#onauthrequired) from the [Security](#security) component if exists.
+
+#### errorComponent
+
+`SecureRoute` runs internal `handleLogin` process which may throw Error when `authState.isAuthenticated` is false. By default, the Error will be rendered with `OktaError` component. If you wish to customise the display of such error messages, you can pass your own component as an `errorComponent` prop to `<SecureRoute>`.  The error value will be passed to the `errorComponent` as the `error` prop.
+
+#### `react-router` related props
   
 `SecureRoute` integrates with `react-router`.  Other routers will need their own methods to ensure authentication using the hooks/HOC props provided by this SDK.
 

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -69,11 +69,7 @@ const Security: React.FC<{
     oktaAuth.authStateManager.subscribe(handler);
 
     // Trigger an initial change event to make sure authState is latest
-    if (!oktaAuth.isLoginRedirect()) {
-      // Calculates initial auth state and fires change event for listeners
-      // Also starts the token auto-renew service
-      oktaAuth.start();
-    }
+    oktaAuth.start();
 
     return () => {
       oktaAuth.authStateManager.unsubscribe(handler);

--- a/test/jest/security.test.tsx
+++ b/test/jest/security.test.tsx
@@ -43,7 +43,6 @@ describe('<Security />', () => {
         subscribe: jest.fn(),
         unsubscribe: jest.fn(),
       },
-      isLoginRedirect: jest.fn().mockImplementation(() => false),
       start: jest.fn(),
       stop: jest.fn(),
     };
@@ -185,20 +184,6 @@ describe('<Security />', () => {
     expect(oktaAuth.authStateManager.subscribe).toHaveBeenCalledTimes(1);
     expect(oktaAuth.start).toHaveBeenCalledTimes(1);
     expect(MyComponent).toHaveBeenCalledTimes(2);
-  });
-
-  it('should not call start when in login redirect state', () => {
-    oktaAuth.isLoginRedirect = jest.fn().mockImplementation(() => true);
-    const mockProps = {
-      oktaAuth,
-      restoreOriginalUri
-    };
-    mount(
-      <MemoryRouter>
-        <Security {...mockProps} />
-      </MemoryRouter>
-    );
-    expect(oktaAuth.start).not.toHaveBeenCalled();
   });
 
   it('subscribes to "authStateChange" and updates the context', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?


Issue Number: OKTA-431793


## What is the new behavior?

In Chrome, when `Block all cookies (not recommended)` is selected, error is thrown when try to access any browser storage (localStorage, sessionStorage, cookies), this will cause uncaught error for SecureRoute (error is thrown from: oktaAuth.setOriginalUri ), this PR provides a way for developers to catch that error and handle it gracefully in UI.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

