### PR TITLE
Call updateAuthState when handleLoginRedirect fails

### DIFF
--- a/src/LoginCallback.tsx
+++ b/src/LoginCallback.tsx
@@ -30,12 +30,13 @@ const LoginCallback: React.FC<LoginCallbackProps> = ({ errorComponent, loadingEl
       onAuthResume();
       return;
     }
-    oktaAuth.handleLoginRedirect().then(() => {
-      // In `<Security>` component service was not started in case of login redirect.
-      // Start it now after `restoreOriginalUri` has been called and route changed.
-      oktaAuth.start();
-    }).catch(e => {
+
+    // In case of login redirect service was started in `<Security>` component
+    //  but authState was not updated
+    oktaAuth.handleLoginRedirect().catch(e => {
       setCallbackError(e);
+    }).finally(() => {
+      oktaAuth.authStateManager.updateAuthState();
     });
   }, [oktaAuth]);
 

--- a/test/jest/loginCallback.test.tsx
+++ b/test/jest/loginCallback.test.tsx
@@ -66,6 +66,25 @@ describe('<LoginCallback />', () => {
     expect(oktaAuth.handleLoginRedirect).toHaveBeenCalledTimes(1);
   });
 
+  it('calls updateAuthState when handleLoginRedirect fails', async () => {
+    authState = null;
+    const errorMsg = 'error on callback';
+    oktaAuth.handleLoginRedirect.mockImplementation(() => {
+      return Promise.reject(new Error(errorMsg));
+    });
+    const wrapper = mount(
+      <Security {...mockProps}>
+        <LoginCallback />
+      </Security>
+    );
+    return await act(async () => {
+      await wrapper.update(); // handleLoginRedirect
+      await wrapper.update(); // set state
+      expect(oktaAuth.handleLoginRedirect).toHaveBeenCalledTimes(1);
+      expect(oktaAuth.authStateManager.updateAuthState).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('shows errors', () => {
     it('does not render errors without an error', () => { 
       const wrapper = mount(


### PR DESCRIPTION
Fixes https://github.com/okta/okta-react/issues/173

Internal ref: [OKTA-441939](https://oktainc.atlassian.net/browse/OKTA-441939)

Steps to reproduce:
- Visit page with `<LoginCallback>` component with incorrect query parameters (like `http://localhost:8000/login/callback?code=foobar`)
- Error will be thrown in `oktaAuth.handleLoginRedirect()`:  `AuthSdkError: Unable to retrieve OAuth redirect params from storage`
- Try to go to secure route (`<SecureRoute>`)
- Route will not be rendered because `authState` is null (even if user is authenticated)

Reason for this: in `oktaAuth.start()` auth state is not updated for login redirect page:
```js
    if (!this.token.isLoginRedirect()) {
      this.authStateManager.updateAuthState();
    }
```
So fix is to manually call `updateAuthState` after catching error in `handleLoginRedirect`
