### PR TITLE
fix: More robust decouple from react-router v5

### DIFF
--- a/src/SecureRoute.tsx
+++ b/src/SecureRoute.tsx
@@ -16,7 +16,7 @@ import * as ReactRouterDom from 'react-router-dom';
 import { toRelativeUrl } from '@okta/okta-auth-js';
 import OktaError from './OktaError';
 
-const useMatch = ReactRouterDom['useMatch' in ReactRouterDom ? 'useMatch' : 'useRouteMatch'];
+const useMatch: any = (ReactRouterDom as any)['useMatch' in ReactRouterDom ? 'useMatch' : 'useRouteMatch'];
 
 const SecureRoute: React.FC<{
   onAuthRequired?: OnAuthRequiredFunction;

--- a/src/SecureRoute.tsx
+++ b/src/SecureRoute.tsx
@@ -16,6 +16,8 @@ import * as ReactRouterDom from 'react-router-dom';
 import { toRelativeUrl } from '@okta/okta-auth-js';
 import OktaError from './OktaError';
 
+const useMatch = ReactRouterDom['useMatch' in ReactRouterDom ? 'useMatch' : 'useRouteMatch'];
+
 const SecureRoute: React.FC<{
   onAuthRequired?: OnAuthRequiredFunction;
   errorComponent?: React.ComponentType<{ error: Error }>;
@@ -25,7 +27,7 @@ const SecureRoute: React.FC<{
   ...routeProps
 }) => { 
   const { oktaAuth, authState, _onAuthRequired } = useOktaAuth();
-  const match = ReactRouterDom.useRouteMatch(routeProps);
+  const match = useMatch(routeProps);
   const pendingLogin = React.useRef(false);
   const [handleLoginError, setHandleLoginError] = React.useState<Error | null>(null);
   const ErrorReporter = errorComponent || OktaError;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix

## What is the current behavior?

```
./node_modules/@okta/okta-react/bundles/okta-react.esm.js 284:14-42
export 'useRouteMatch' (imported as 'ReactRouterDom') was not found in 'react-router-dom' (possible exports: BrowserRouter, HashRouter, Link, MemoryRouter, NavLink, Navigate, Outlet, Route, Router, Routes, UNSAFE_LocationContext, UNSAFE_NavigationContext, UNSAFE_RouteContext, createRoutesFromChildren, createSearchParams, generatePath, matchPath, matchRoutes, renderMatches, resolvePath, unstable_HistoryRouter, useHref, useInRouterContext, useLinkClickHandler, useLocation, useMatch, useNavigate, useNavigationType, useOutlet, useOutletContext, useParams, useResolvedPath, useRoutes, useSearchParams)
```

Issue Number: #178

## What is the new behavior?
Works with react-router 5 & 6, but `SecureRoute` still only works with react-router 5 (as `useMatch` uses different args)

## Does this PR introduce a breaking change?
- [x] No
