### PR TITLE
Use siw-platform-scripts instead of artifactory url 

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -16,7 +16,7 @@ test_suites:
     - name: e2e
       script_path: /root/okta/okta-react/scripts
       sort_order: '3'
-      timeout: '10'
+      timeout: '15'
       script_name: e2e
       criteria: MERGE
       queue_name: small
@@ -30,7 +30,7 @@ test_suites:
     - name: e2e-v6
       script_path: /root/okta/okta-react/scripts
       sort_order: '5'
-      timeout: '10'
+      timeout: '15'
       script_name: e2e-v6
       criteria: MERGE
       queue_name: small

--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -21,8 +21,8 @@ export CLIENT_ID=0oapmwm72082GXal14x6
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
 export USERNAME=george@acme.com
 get_vault_secret_key devex/samples-javascript password PASSWORD
-export ORG_OIE_ENABLED=true
-export USE_INTERACTION_CODE=true
+export ORG_OIE_ENABLED=
+export USE_INTERACTION_CODE=
 
 # modifies the package.json of all workspaces to the latest 6.x version
 ./scripts/utils/sync-ws-auth-js.sh $(yarn info @okta/okta-auth-js@^6 --json | jq '.data.versions | last' | tr -d \")

--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $DIR/utils/local.sh
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
 setup_service java 1.8.222
@@ -13,7 +15,9 @@ export ISSUER=https://samples-javascript.okta.com/oauth2/default
 export CLIENT_ID=0oapmwm72082GXal14x6
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
 export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key devex/samples-javascript password PASSWORD
+export ORG_OIE_ENABLED=true
+export USE_INTERACTION_CODE=true
 
 # modifies the package.json of all workspaces to the latest 6.x version
 ./scripts/utils/sync-ws-auth-js.sh $(yarn info @okta/okta-auth-js@^6 --json | jq '.data.versions | last' | tr -d \")

--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -4,6 +4,11 @@ DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 source $DIR/utils/local.sh
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
+if [ ! -z "$AUTHJS_VERSION" ]; then
+  echo "Skipping e2e tests against auth-js v6.x"
+  exit ${SUCCESS}
+fi
+
 setup_service java 1.8.222
 setup_service google-chrome-stable 106.0.5249.61-1
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -11,13 +11,13 @@ export CI=true
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
-export ISSUER=https://samples-javascript.okta.com/oauth2/default
-export CLIENT_ID=0oapmwm72082GXal14x6
-export SPA_CLIENT_ID=0oapmwm72082GXal14x6
-export USERNAME=george@acme.com
-get_vault_secret_key devex/samples-javascript password PASSWORD
-export ORG_OIE_ENABLED=
-export USE_INTERACTION_CODE=
+export ISSUER=https://javascript-idx-sdk.okta.com
+export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
+export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
+export USERNAME=mary@acme.com
+get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
+export ORG_OIE_ENABLED=true
+export USE_INTERACTION_CODE=true
 
 if ! yarn test:e2e; then
   echo "e2e tests failed! Exiting..."

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $DIR/utils/local.sh
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
 setup_service java 1.8.222
@@ -13,7 +15,9 @@ export ISSUER=https://samples-javascript.okta.com/oauth2/default
 export CLIENT_ID=0oapmwm72082GXal14x6
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
 export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key devex/samples-javascript password PASSWORD
+export ORG_OIE_ENABLED=true
+export USE_INTERACTION_CODE=true
 
 if ! yarn test:e2e; then
   echo "e2e tests failed! Exiting..."

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -11,13 +11,13 @@ export CI=true
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/e2e"
 
-export ISSUER=https://javascript-idx-sdk.okta.com
-export CLIENT_ID=0oav2oxnlYjULp0Cy5d6
-export SPA_CLIENT_ID=0oa17suj5x9khaVH75d7
-export USERNAME=mary@acme.com
-get_vault_secret_key repo_gh-okta-okta-auth-js/default password PASSWORD
-export ORG_OIE_ENABLED=true
-export USE_INTERACTION_CODE=true
+export ISSUER=https://samples-javascript.okta.com/oauth2/default
+export CLIENT_ID=0oapmwm72082GXal14x6
+export SPA_CLIENT_ID=0oapmwm72082GXal14x6
+export USERNAME=george@acme.com
+get_vault_secret_key devex/samples-javascript password PASSWORD
+export ORG_OIE_ENABLED=
+export USE_INTERACTION_CODE=
 
 if ! yarn test:e2e; then
   echo "e2e tests failed! Exiting..."

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -16,8 +16,8 @@ export CLIENT_ID=0oapmwm72082GXal14x6
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
 export USERNAME=george@acme.com
 get_vault_secret_key devex/samples-javascript password PASSWORD
-export ORG_OIE_ENABLED=true
-export USE_INTERACTION_CODE=true
+export ORG_OIE_ENABLED=
+export USE_INTERACTION_CODE=
 
 if ! yarn test:e2e; then
   echo "e2e tests failed! Exiting..."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,7 @@ source $DIR/utils/siw-platform-scripts.sh
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
-export AUTHJS_VERSION="7.4.0-g64ea6df"
+export AUTHJS_VERSION=""
 
 # Add yarn to the $PATH so npm cli commands do not fail
 export PATH="${PATH}:$(yarn global bin)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,6 +21,7 @@ export PATH="${PATH}:$(yarn global bin)"
 
 cd ${OKTA_HOME}/${REPO}
 
+# if running on bacon
 if [ -n "${TEST_SUITE_ID}" ]; then
   # undo permissions change on scripts/publish.sh
   git checkout -- scripts

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,15 +9,15 @@ source $DIR/utils/siw-platform-scripts.sh
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
 export AUTHJS_VERSION=""
 
-# Add yarn to the $PATH so npm cli commands do not fail
-export PATH="${PATH}:$(yarn global bin)"
-
 # Install required node version
 export NVM_DIR="/root/.nvm"
 NODE_VERSION="${1:-v14.18.3}"
 setup_service node $NODE_VERSION
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
 setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+
+# Add yarn to the $PATH so npm cli commands do not fail
+export PATH="${PATH}:$(yarn global bin)"
 
 cd ${OKTA_HOME}/${REPO}
 
@@ -53,7 +53,7 @@ if [ ! -z "$AUTHJS_VERSION" ]; then
 
   # verify single version of auth-js is installed
   # NOTE: okta-signin-widget will install it's own version of auth-js, filtered out
-  AUTHJS_INSTALLS=$(find ${OKTA_HOME}/${REPO} -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" | wc -l)
+  AUTHJS_INSTALLS=$(find . -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" | wc -l)
   if [ $AUTHJS_INSTALLS -gt 1 ]
   then
     echo "ADDITIONAL AUTH JS INSTALL DETECTED"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,9 +1,13 @@
 #!/bin/bash -xe
 
+DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $DIR/utils/local.sh
+source $DIR/utils/siw-platform-scripts.sh
+
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
-export AUTHJS_VERSION=""
+export AUTHJS_VERSION="7.4.0-g64ea6df"
 
 # Add yarn to the $PATH so npm cli commands do not fail
 export PATH="${PATH}:$(yarn global bin)"
@@ -17,32 +21,17 @@ setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
 cd ${OKTA_HOME}/${REPO}
 
-# undo permissions change on scripts/publish.sh
-git checkout -- scripts
+if [ -n "${TEST_SUITE_ID}" ]; then
+  # undo permissions change on scripts/publish.sh
+  git checkout -- scripts
 
-# ensure we're in a branch on the correct sha
-git checkout $BRANCH
-git reset --hard $SHA
+  # ensure we're in a branch on the correct sha
+  git checkout $BRANCH
+  git reset --hard $SHA
 
-git config --global user.email "oktauploader@okta.com"
-git config --global user.name "oktauploader-okta"
-
-#!/bin/bash
-YARN_REGISTRY=https://registry.yarnpkg.com
-OKTA_REGISTRY=${ARTIFACTORY_URL}/api/npm/npm-okta-master
-
-# Yarn does not utilize the npmrc/yarnrc registry configuration
-# if a lockfile is present. This results in `yarn install` problems
-# for private registries. Until yarn@2.0.0 is released, this is our current
-# workaround.
-#
-# Related issues:
-#  - https://github.com/yarnpkg/yarn/issues/5892
-#  - https://github.com/yarnpkg/yarn/issues/3330
-
-# Replace yarn registry with Okta's
-echo "Replacing $YARN_REGISTRY with $OKTA_REGISTRY within yarn.lock files..."
-sed -i "s#${YARN_REGISTRY}#${OKTA_REGISTRY}#" yarn.lock
+  git config --global user.email "oktauploader@okta.com"
+  git config --global user.name "oktauploader-okta"
+fi
 
 # Install dependencies but do not build
 if ! yarn install --frozen-lockfile --ignore-scripts; then
@@ -50,31 +39,21 @@ if ! yarn install --frozen-lockfile --ignore-scripts; then
   exit ${FAILED_SETUP}
 fi
 
-# Revert the original change(s)
-echo "Replacing $OKTA_REGISTRY with $YARN_REGISTRY within yarn.lock files..."
-sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" yarn.lock
-
 # Install a specific version of auth-js, used by downstream artifact builds
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
-  npm config set strict-ssl false
-
-  AUTHJS_URI=https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz
-  if ! yarn add -DW --ignore-scripts ${AUTHJS_URI}; then
-    echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"
-    exit ${FAILED_SETUP}
-  fi
 
   # modifies the package.json of all workspaces depending on @okta/okta-auth-js to point to the upstream version
-  ./scripts/utils/sync-ws-auth-js.sh ${AUTHJS_URI}
-  yarn --ignore-scripts
+  $DIR/utils/sync-ws-auth-js.sh ${AUTHJS_VERSION}
 
-  npm config set strict-ssl true
+  install_siw_platform_scripts
+  install_artifact @okta/okta-auth-js "${AUTHJS_VERSION}"
+
   echo "AUTHJS_VERSION installed: ${AUTHJS_VERSION}"
 
   # verify single version of auth-js is installed
   # NOTE: okta-signin-widget will install it's own version of auth-js, filtered out
-  AUTHJS_INSTALLS=$(find . -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" | wc -l)
+  AUTHJS_INSTALLS=$(find ${OKTA_HOME}/${REPO} -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" | wc -l)
   if [ $AUTHJS_INSTALLS -gt 1 ]
   then
     echo "ADDITIONAL AUTH JS INSTALL DETECTED"

--- a/scripts/unit-v6.sh
+++ b/scripts/unit-v6.sh
@@ -7,6 +7,11 @@ source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/unit"
 
+if [ ! -z "$AUTHJS_VERSION" ]; then
+  echo "Skipping unit tests against auth-js v6.x"
+  exit ${SUCCESS}
+fi
+
 if ! yarn add -DW --ignore-scripts @okta/okta-auth-js@^6; then
   echo "auth-js v6.x could not be installed"
   exit ${FAILED_SETUP}

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -25,11 +25,7 @@ if [ -z "${TEST_SUITE_ID}" ]; then
   }
 
   get_secret () {
-    # ensures the env var is set
-    if [ -z "$(echo "$3")" ]; then
-      echo "$3 is not defined. Exiting..."
-      exit 1
-    fi
+    echo 'noop'
   }
 
   set -x  # when running locally, might as well see all the commands being ran

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -25,7 +25,21 @@ if [ -z "${TEST_SUITE_ID}" ]; then
   }
 
   get_secret () {
-    echo 'noop'
+    # ensures the env var is set
+    key="$2"
+    if [ -z "${!key}" ]; then
+      echo "$key is not defined. Exiting..."
+      exit 1
+    fi
+  }
+
+  get_vault_secret_key () {
+    # ensures the env var is set
+    key="$3"
+    if [ -z "${!key}" ]; then
+      echo "$key is not defined. Exiting..."
+      exit 1
+    fi
   }
 
   set -x  # when running locally, might as well see all the commands being ran

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# if not running on bacon
+if [ -z "${TEST_SUITE_ID}" ]; then
+  export OKTA_HOME=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd)
+  export REPO="."
+  export TEST_SUITE_TYPE_FILE=/dev/null
+  export TEST_RESULT_FILE_DIR_FILE=/dev/null
+
+  ### (known) Bacon exit codes
+  # success
+  export SUCCESS=0
+  export PUBLISH_TYPE_AND_RESULT_DIR=0
+  export PUBLISH_TYPE_AND_RESULT_DIR_BUT_SUCCEED_IF_NO_RESULTS=0
+  # failure
+  export FAILURE=1
+  export FAILED_SETUP=1
+  export TEST_FAILURE=1
+  export PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL=1
+  export PUBLISH_ARTIFACTORY_FAILURE=1
+
+  # bacon commands
+  setup_service () {
+    echo 'noop'
+  }
+
+  get_vault_secret_key () {
+    # ensures the env var is set
+    if [ -z "$(echo "$3")" ]; then
+      echo "$3 is not defined. Exiting..."
+      exit 1
+    fi
+  }
+
+  set -x  # when running locally, might as well see all the commands being ran
+fi

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -24,7 +24,7 @@ if [ -z "${TEST_SUITE_ID}" ]; then
     echo 'noop'
   }
 
-  get_vault_secret_key () {
+  get_secret () {
     # ensures the env var is set
     if [ -z "$(echo "$3")" ]; then
       echo "$3 is not defined. Exiting..."

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# if running on bacon
+if [ -n "${TEST_SUITE_ID}" ]; then
+  export SIW_PLATFORM_ENV="bacon"
+else
+  export SIW_PLATFORM_ENV="local"
+fi
+
+orig_ssl=$(yarn config get strict-ssl)
+orig_registry=$(yarn config get @okta:registry)
+REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"
+
+update_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    yarn config set @okta:registry ${REGISTRY}
+    yarn config set strict-ssl false
+    trap restore_yarn_config EXIT
+  fi
+}
+
+restore_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    if [ "$orig_registry" == "undefined" ] ; then
+      yarn config delete @okta:registry
+    else
+      yarn config set @okta:registry $orig_registry
+    fi
+    yarn config set strict-ssl $orig_ssl
+  fi
+}
+
+install_siw_platform_scripts () {
+  update_yarn_config
+  if ! yarn global add @okta/siw-platform-scripts ; then
+    echo "siw-platform-scripts could not be installed"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}
+
+install_artifact () {
+  # $1 = package name
+  # $2 = version
+  update_yarn_config
+  if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $1 -v $2 ; then
+    echo "$1 could not be installed via siw-platform: $1"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -44,7 +44,7 @@ install_artifact () {
   # $2 = version
   update_yarn_config
   if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $1 -v $2 ; then
-    echo "$1 could not be installed via siw-platform: $1"
+    echo "$1 $2 could not be installed via siw-platform"
     exit ${FAILED_SETUP}
   fi
   restore_yarn_config

--- a/scripts/utils/sync-ws-auth-js.sh
+++ b/scripts/utils/sync-ws-auth-js.sh
@@ -4,9 +4,12 @@
 
 workspaces=$(yarn -s workspaces info | jq 'map(..|objects|select(.location).location)[1:] | @sh' | tr -d \'\")
 
+# project directory
+pdir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd)
+
 for loc in $workspaces
 do
   echo $loc
-  json=$(cat $loc/package.json |  jq --arg version $@ 'if .dependencies | has("@okta/okta-auth-js") then .dependencies["@okta/okta-auth-js"] = $version else . end') && \
-  echo -E "${json}" > $loc/package.json
+  json=$(cat $pdir/$loc/package.json |  jq --arg version $@ 'if .dependencies | has("@okta/okta-auth-js") then .dependencies["@okta/okta-auth-js"] = $version else . end') && \
+  echo -E "${json}" > "$pdir/$loc/package.json"
 done


### PR DESCRIPTION
- Use `siw-platform-scripts` to install auth-js instead of internal artifactory url
- Increased timeouts for e2e Bacon tasks
- Added support of [local running](https://github.com/okta/okta-react/pull/259/files#diff-2e35321119f1354c7c96c55fe060acb9a16f68c56114f9a0e0d6560b193cb986) e2e and setup scripts
- Cleaned up e2e script: Removed obsolete [registry workaround for yarn](https://github.com/okta/okta-react/pull/259/files#diff-ce435f38623d032d25670f2c63a430dfd1a02db661d10c1ef031cbef2f0f0ef0L43-L45).

Internal ref: [OKTA-607421](https://oktainc.atlassian.net/browse/OKTA-607421)