### PR TITLE
fix[okta-react]: add missing await on restoreOriginalUri

### DIFF
--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -57,7 +57,7 @@ const Security: React.FC<{
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     oktaAuth.options.restoreOriginalUri = (async (oktaAuth: unknown, originalUri: string) => {
-      restoreOriginalUri(oktaAuth as OktaAuth, originalUri);
+      await restoreOriginalUri(oktaAuth as OktaAuth, originalUri);
     }) as ((oktaAuth: OktaAuth, originalUri?: string) => Promise<void>);
 
   }, []); // empty array, only check on component mount


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## What is the current behavior?

Currently when providing a `restoreOriginalUri` function that returns a `Promise` to the `<Security />` component, this promise is not awaited on in `oktaAuth.handleLoginRedirect()`. This means that relying on the resolution of the `okta.handleLoginRedirect()` promise does not reliably indicate that the redirect has completed. 

Issue Number: N/A


## What is the new behavior?

If `restoreOriginalUri` returns a promise, it will be awaited when calling `oktaAuth.handleLoginRedirect()`.

## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

