### PR TITLE
perf: apply useMemo to the value passed to OktaContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.10.0
+
+-[#295](https://github.com/okta/okta-react/pull/295) fix: wraps `OktaContext` in a `useMemo` to reduce re-renders and improve performance
+  - Resolve [#294](https://github.com/okta/okta-react/pull/294)
+
 # 6.9.0
 
 ### Bug Fixes

--- a/src/Security.tsx
+++ b/src/Security.tsx
@@ -12,7 +12,7 @@
 
 import * as React from 'react';
 import { AuthSdkError, AuthState, OktaAuth } from '@okta/okta-auth-js';
-import OktaContext, { OnAuthRequiredFunction, RestoreOriginalUriFunction } from './OktaContext';
+import OktaContext, { IOktaContext, OnAuthRequiredFunction, RestoreOriginalUriFunction } from './OktaContext';
 import OktaError from './OktaError';
 import { compare as compareVersions } from 'compare-versions';
 
@@ -92,6 +92,12 @@ const Security: React.FC<{
     };
   }, [oktaAuth]);
 
+  const oktaContextValue = React.useMemo((): IOktaContext => ({
+    oktaAuth,
+    authState,
+    _onAuthRequired: onAuthRequired
+  }), [oktaAuth, authState, onAuthRequired]);
+
   if (!oktaAuth) {
     const err = new AuthSdkError('No oktaAuth instance passed to Security Component.');
     return <OktaError error={err} />;
@@ -120,11 +126,7 @@ const Security: React.FC<{
   }
 
   return (
-    <OktaContext.Provider value={{ 
-      oktaAuth, 
-      authState, 
-      _onAuthRequired: onAuthRequired
-    }}>
+    <OktaContext.Provider value={oktaContextValue}>
       {children}
     </OktaContext.Provider>
   );


### PR DESCRIPTION
By memoizing this value using React's `useMemo`, the context value is kept stable while none of the values inside the value change. This helps to prevent re-renders in components that consume the Okta context (through `useOktaAuth`).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

