### PR TITLE
feat[client-js]: Adds React Router v8 sample app for @okta/okta-react-client-js

### DIFF
--- a/test/apps/client-js-router-v8-app/.env.development
+++ b/test/apps/client-js-router-v8-app/.env.development
@@ -1,0 +1,2 @@
+# Forces Vite to run a development build: https://vitejs.dev/guide/env-and-mode.html#modes
+NODE_ENV=development

--- a/test/apps/client-js-router-v8-app/.gitignore
+++ b/test/apps/client-js-router-v8-app/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/test/apps/client-js-router-v8-app/index.html
+++ b/test/apps/client-js-router-v8-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>okta-react client-js + React Router v8 sample</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/test/apps/client-js-router-v8-app/package.json
+++ b/test/apps/client-js-router-v8-app/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@okta/test.app.client-js-router-v8-app",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "prestart": "vite build",
+    "start": "vite preview --port 8080",
+    "start:dev": "vite build --mode development && vite preview --port 8080",
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.3.0",
+    "@okta/auth-foundation": "*",
+    "@okta/oauth2-flows": "*",
+    "@okta/spa-platform": "*",
+    "@okta/okta-react": "*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "@vitejs/plugin-react": "^6.0.5",
+    "typescript": "^5.6.3",
+    "vite": "^8.2.1"
+  }
+}

--- a/test/apps/client-js-router-v8-app/public/resource.json
+++ b/test/apps/client-js-router-v8-app/public/resource.json
@@ -1,0 +1,4 @@
+{
+  "message": "This is a protected resource, fetched via createFetchLoader.",
+  "widgets": ["foo", "bar", "baz"]
+}

--- a/test/apps/client-js-router-v8-app/src/ErrorBoundary.tsx
+++ b/test/apps/client-js-router-v8-app/src/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as React from 'react';
+import { Link, isRouteErrorResponse, useRouteError } from 'react-router';
+
+const ErrorBoundary: React.FC = () => {
+  const error = useRouteError();
+
+  const message = isRouteErrorResponse(error)
+    ? `${error.status} ${error.statusText}`
+    : error instanceof Error
+      ? error.message
+      : 'Unknown error';
+
+  return (
+    <div>
+      <h1>Error</h1>
+      <p id="error-message">{message}</p>
+      <Link to="/">Home</Link>
+    </div>
+  );
+};
+
+export default ErrorBoundary;

--- a/test/apps/client-js-router-v8-app/src/Home.tsx
+++ b/test/apps/client-js-router-v8-app/src/Home.tsx
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as React from 'react';
+import { Link } from 'react-router';
+import { Credential } from '@okta/spa-platform';
+import { orchestrator, signOutFlow } from './auth';
+
+const Home: React.FC = () => {
+  const [credential, setCredential] = React.useState<Credential | null>(null);
+
+  React.useEffect(() => {
+    Credential.getDefault().then(setCredential);
+  }, []);
+
+  const signIn = async () => {
+    // Redirects to Okta - the returned promise never resolves because the page navigates away.
+    await orchestrator.getToken();
+  };
+
+  const signOut = async () => {
+    const idToken = credential?.token.idToken?.toString();
+    if (!credential || !idToken) {
+      return;
+    }
+    // Ending the Okta session redirect doesn't clear locally stored credentials - that's on the app.
+    await credential.remove();
+    const url = await signOutFlow.start(idToken);
+    window.location.assign(url);
+  };
+
+  return (
+    <div>
+      <h1>okta-react client-js + React Router v8 sample</h1>
+      {credential ? (
+        <button id="logout-button" onClick={signOut}>Sign out</button>
+      ) : (
+        <button id="login-button" onClick={signIn}>Sign in</button>
+      )}
+      <nav>
+        <Link to="/protected">Protected</Link>
+        {' | '}
+        <Link to="/resource">Resource</Link>
+      </nav>
+    </div>
+  );
+};
+
+export default Home;

--- a/test/apps/client-js-router-v8-app/src/Home.tsx
+++ b/test/apps/client-js-router-v8-app/src/Home.tsx
@@ -16,10 +16,10 @@ import { Credential } from '@okta/spa-platform';
 import { orchestrator, signOutFlow } from './auth';
 
 const Home: React.FC = () => {
-  const [credential, setCredential] = React.useState<Credential | null>(null);
+  const [hasCredential, setHasCredential] = React.useState(false);
 
   React.useEffect(() => {
-    Credential.getDefault().then(setCredential);
+    Credential.getDefault().then((credential) => setHasCredential(credential !== null));
   }, []);
 
   const signIn = async () => {
@@ -28,6 +28,7 @@ const Home: React.FC = () => {
   };
 
   const signOut = async () => {
+    const credential = await Credential.getDefault();
     const idToken = credential?.token.idToken?.toString();
     if (!credential || !idToken) {
       return;
@@ -41,7 +42,7 @@ const Home: React.FC = () => {
   return (
     <div>
       <h1>okta-react client-js + React Router v8 sample</h1>
-      {credential ? (
+      {hasCredential ? (
         <button id="logout-button" onClick={signOut}>Sign out</button>
       ) : (
         <button id="login-button" onClick={signIn}>Sign in</button>

--- a/test/apps/client-js-router-v8-app/src/LoginCallback.tsx
+++ b/test/apps/client-js-router-v8-app/src/LoginCallback.tsx
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as React from 'react';
+
+// This route's loader (createLoginCallbackLoader) always resolves the flow and
+// redirects before the router renders a route element, so this is never shown
+// except momentarily while the loader is in flight.
+const LoginCallback: React.FC = () => <p id="login-callback-loading">Loading...</p>;
+
+export default LoginCallback;

--- a/test/apps/client-js-router-v8-app/src/Protected.tsx
+++ b/test/apps/client-js-router-v8-app/src/Protected.tsx
@@ -1,0 +1,31 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as React from 'react';
+import { Link, useLoaderData } from 'react-router';
+import type { Token } from '@okta/auth-foundation';
+
+const Protected: React.FC = () => {
+  const token = useLoaderData() as Token;
+  const claims = token.idToken?.claims;
+
+  return (
+    <div>
+      <h1>Protected</h1>
+      <p>Loaded via <code>createTokenLoader</code>.</p>
+      <pre id="claims">{JSON.stringify(claims, null, 2)}</pre>
+      <Link to="/">Home</Link>
+    </div>
+  );
+};
+
+export default Protected;

--- a/test/apps/client-js-router-v8-app/src/Resource.tsx
+++ b/test/apps/client-js-router-v8-app/src/Resource.tsx
@@ -14,13 +14,13 @@ import * as React from 'react';
 import { Link, useLoaderData } from 'react-router';
 
 const Resource: React.FC = () => {
-  const userInfo = useLoaderData();
+  const resource = useLoaderData();
 
   return (
     <div>
       <h1>Resource</h1>
-      <p>Loaded via <code>createFetchLoader</code> (<code>/oauth2/v1/userinfo</code>).</p>
-      <pre id="userinfo">{JSON.stringify(userInfo, null, 2)}</pre>
+      <p>Loaded via <code>createFetchLoader</code> (<code>/resource.json</code>).</p>
+      <pre id="resource">{JSON.stringify(resource, null, 2)}</pre>
       <Link to="/">Home</Link>
     </div>
   );

--- a/test/apps/client-js-router-v8-app/src/Resource.tsx
+++ b/test/apps/client-js-router-v8-app/src/Resource.tsx
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as React from 'react';
+import { Link, useLoaderData } from 'react-router';
+
+const Resource: React.FC = () => {
+  const userInfo = useLoaderData();
+
+  return (
+    <div>
+      <h1>Resource</h1>
+      <p>Loaded via <code>createFetchLoader</code> (<code>/oauth2/v1/userinfo</code>).</p>
+      <pre id="userinfo">{JSON.stringify(userInfo, null, 2)}</pre>
+      <Link to="/">Home</Link>
+    </div>
+  );
+};
+
+export default Resource;

--- a/test/apps/client-js-router-v8-app/src/auth.ts
+++ b/test/apps/client-js-router-v8-app/src/auth.ts
@@ -20,11 +20,6 @@ import {
 
 const { ISSUER, CLIENT_ID } = process.env;
 
-// The userinfo endpoint always lives under the issuing authorization server, not the org root -
-// for a custom authorization server (e.g. `.../oauth2/default`) that's `.../oauth2/default/v1/userinfo`,
-// which differs from the org authorization server's `.../oauth2/v1/userinfo`.
-export const userInfoUrl = new URL(`${ISSUER}/v1/userinfo`);
-
 export const client = new OAuth2Client({
   issuer: ISSUER!,
   clientId: CLIENT_ID!,

--- a/test/apps/client-js-router-v8-app/src/auth.ts
+++ b/test/apps/client-js-router-v8-app/src/auth.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  OAuth2Client,
+  AuthorizationCodeFlow,
+  SessionLogoutFlow,
+  AuthorizationCodeFlowOrchestrator,
+  FetchClient,
+} from '@okta/spa-platform';
+
+const { ISSUER, CLIENT_ID } = process.env;
+
+// The userinfo endpoint always lives under the issuing authorization server, not the org root -
+// for a custom authorization server (e.g. `.../oauth2/default`) that's `.../oauth2/default/v1/userinfo`,
+// which differs from the org authorization server's `.../oauth2/v1/userinfo`.
+export const userInfoUrl = new URL(`${ISSUER}/v1/userinfo`);
+
+export const client = new OAuth2Client({
+  issuer: ISSUER!,
+  clientId: CLIENT_ID!,
+  scopes: ['openid', 'profile', 'email'],
+});
+
+export const signInFlow = new AuthorizationCodeFlow(client, {
+  redirectUri: `${window.location.origin}/login/callback`,
+});
+
+export const signOutFlow = new SessionLogoutFlow(client, {
+  logoutRedirectUri: `${window.location.origin}/`,
+});
+
+// `emitBeforeRedirect: false` skips the `login_prompt_required` event - this sample has no
+// confirmation UI to gate the redirect on, so `getToken()` should redirect immediately.
+export const orchestrator = new AuthorizationCodeFlowOrchestrator(signInFlow, {
+  emitBeforeRedirect: false,
+});
+
+export const fetchClient = new FetchClient(orchestrator);
+
+// If the user abandons a sign-in redirect (e.g. hits the browser back button on Okta's hosted page
+// before completing it) and the browser restores this page from the back/forward cache, `signInFlow`
+// comes back with `inProgress` still stuck `true` from the aborted attempt - `start()`/`resume()` only
+// ever reset it on completion or failure, neither of which runs for an abandoned redirect. That stuck
+// state makes every later `orchestrator.getToken()` call throw `flow already in progress` immediately.
+// `pageshow`'s `persisted` flag is the standard signal for a bfcache restore, so reset here.
+window.addEventListener('pageshow', (event) => {
+  if (event.persisted) {
+    signInFlow.reset();
+  }
+});

--- a/test/apps/client-js-router-v8-app/src/main.tsx
+++ b/test/apps/client-js-router-v8-app/src/main.tsx
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import { RouterProvider } from 'react-router';
+import { Credential } from '@okta/spa-platform';
+import { router } from './router';
+
+if (import.meta.env.DEV) {
+  // Exposed for manual testing from the browser console, e.g.:
+  //   const cred = await __auth.Credential.getDefault();
+  //   await cred.revoke();   // invalidates the access token server-side
+  //   await cred.refresh();  // forces a refresh attempt (throws: no refresh token in this app's scopes)
+  (window as unknown as { __auth: unknown }).__auth = { Credential };
+}
+
+const container = document.getElementById('root');
+
+createRoot(container!).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>,
+);

--- a/test/apps/client-js-router-v8-app/src/router.tsx
+++ b/test/apps/client-js-router-v8-app/src/router.tsx
@@ -11,17 +11,16 @@
  */
 
 import { createBrowserRouter } from 'react-router';
-import {
-  createFetchLoader,
-  createTokenLoader,
-  createLoginCallbackLoader,
-} from '@okta/okta-react/client-js';
+import { createFetchLoader, createLoadersFromOrchestrator } from '@okta/okta-react/client-js';
 import { orchestrator, fetchClient } from './auth';
 import Home from './Home';
 import Protected from './Protected';
 import Resource from './Resource';
 import LoginCallback from './LoginCallback';
 import ErrorBoundary from './ErrorBoundary';
+
+const fetchResource = createFetchLoader(fetchClient);
+const { tokenLoader, loginCallbackLoader } = createLoadersFromOrchestrator(orchestrator);
 
 export const router = createBrowserRouter([
   {
@@ -32,19 +31,19 @@ export const router = createBrowserRouter([
   {
     path: '/protected',
     element: <Protected />,
-    loader: createTokenLoader(orchestrator),
+    loader: () => tokenLoader(),
     errorElement: <ErrorBoundary />,
   },
   {
     path: '/resource',
     element: <Resource />,
-    loader: createFetchLoader(fetchClient, () => '/resource.json'),
+    loader: () => fetchResource('/resource.json'),
     errorElement: <ErrorBoundary />,
   },
   {
     path: '/login/callback',
     element: <LoginCallback />,
-    loader: createLoginCallbackLoader(orchestrator),
+    loader: loginCallbackLoader,
     errorElement: <ErrorBoundary />,
   },
 ]);

--- a/test/apps/client-js-router-v8-app/src/router.tsx
+++ b/test/apps/client-js-router-v8-app/src/router.tsx
@@ -1,0 +1,50 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { createBrowserRouter } from 'react-router';
+import {
+  createFetchLoader,
+  createTokenLoader,
+  createLoginCallbackLoader,
+} from '@okta/okta-react/client-js';
+import { orchestrator, fetchClient, userInfoUrl } from './auth';
+import Home from './Home';
+import Protected from './Protected';
+import Resource from './Resource';
+import LoginCallback from './LoginCallback';
+import ErrorBoundary from './ErrorBoundary';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Home />,
+    errorElement: <ErrorBoundary />,
+  },
+  {
+    path: '/protected',
+    element: <Protected />,
+    loader: createTokenLoader(orchestrator),
+    errorElement: <ErrorBoundary />,
+  },
+  {
+    path: '/resource',
+    element: <Resource />,
+    loader: createFetchLoader(fetchClient, () => userInfoUrl),
+    errorElement: <ErrorBoundary />,
+  },
+  {
+    path: '/login/callback',
+    element: <LoginCallback />,
+    loader: createLoginCallbackLoader(orchestrator),
+    errorElement: <ErrorBoundary />,
+  },
+]);

--- a/test/apps/client-js-router-v8-app/src/router.tsx
+++ b/test/apps/client-js-router-v8-app/src/router.tsx
@@ -16,7 +16,7 @@ import {
   createTokenLoader,
   createLoginCallbackLoader,
 } from '@okta/okta-react/client-js';
-import { orchestrator, fetchClient, userInfoUrl } from './auth';
+import { orchestrator, fetchClient } from './auth';
 import Home from './Home';
 import Protected from './Protected';
 import Resource from './Resource';
@@ -38,7 +38,7 @@ export const router = createBrowserRouter([
   {
     path: '/resource',
     element: <Resource />,
-    loader: createFetchLoader(fetchClient, () => userInfoUrl),
+    loader: createFetchLoader(fetchClient, () => '/resource.json'),
     errorElement: <ErrorBoundary />,
   },
   {

--- a/test/apps/client-js-router-v8-app/src/vite-env.d.ts
+++ b/test/apps/client-js-router-v8-app/src/vite-env.d.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/// <reference types="vite/client" />
+
+// vite.config.js replaces `process.env` with a literal object at build time
+// (see the `define` block); this app has no @types/node dependency.
+declare const process: { env: Record<string, string | undefined> };

--- a/test/apps/client-js-router-v8-app/tsconfig.json
+++ b/test/apps/client-js-router-v8-app/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/test/apps/client-js-router-v8-app/tsconfig.node.json
+++ b/test/apps/client-js-router-v8-app/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/test/apps/client-js-router-v8-app/vite.config.js
+++ b/test/apps/client-js-router-v8-app/vite.config.js
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import oktaEnv from '@okta/env';
+
+oktaEnv.setEnvironmentVarsFromTestEnv(__dirname);
+
+process.env.CLIENT_ID = process.env.SPA_CLIENT_ID || process.env.CLIENT_ID;
+process.env.OKTA_TESTING_DISABLEHTTPSCHECK = process.env.OKTA_TESTING_DISABLEHTTPSCHECK || false;
+
+const env = {};
+
+// List of environment variables made available to the app
+[
+  'ISSUER',
+  'CLIENT_ID',
+  'OKTA_TESTING_DISABLEHTTPSCHECK',
+].forEach((key) => {
+  if (!process.env[key]) {
+    throw new Error(`Environment variable ${key} must be set. See README.md`);
+  }
+  env[key] = process.env[key];
+});
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    'process.env': env
+  },
+  server: {
+    port: process.env.PORT || 8080
+  },
+  build: {
+    rollupOptions: {
+      // always throw with build warnings, except for react-router's own internal
+      // circular import among its (unused, SSR-only) dist chunks
+      onwarn (warning, warn) {
+        if (warning.code === 'CIRCULAR_DEPENDENCY' && warning.message.includes('react-router')) {
+          return;
+        }
+        warn('\nBuild warning happened, customize "onwarn" callback in vite.config.js to handle this error.');
+        throw new Error(warning);
+      }
+    }
+  }
+})

--- a/test/apps/client-js-router-v8-app/vite.config.js
+++ b/test/apps/client-js-router-v8-app/vite.config.js
@@ -44,12 +44,8 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      // always throw with build warnings, except for react-router's own internal
-      // circular import among its (unused, SSR-only) dist chunks
+      // always throw with build warnings, customize "onwarn" callback in vite.config.js to handle this error.
       onwarn (warning, warn) {
-        if (warning.code === 'CIRCULAR_DEPENDENCY' && warning.message.includes('react-router')) {
-          return;
-        }
         warn('\nBuild warning happened, customize "onwarn" callback in vite.config.js to handle this error.');
         throw new Error(warning);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,12 +1586,12 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@okta/auth-foundation@^0.6.0":
+"@okta/auth-foundation@*", "@okta/auth-foundation@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@okta/auth-foundation/-/auth-foundation-0.6.0.tgz#25b729bc8d15de53025e08d619f4ec19e072687f"
   integrity sha512-AueDPbgox+E0To/SYrxpjQwiyI2HwxNqp1aWn/90ZonevTiJAk+o5kSp9i+Y7j08aUEc1NGXKJj989I+ZXsRbQ==
 
-"@okta/oauth2-flows@^0.6.0":
+"@okta/oauth2-flows@*", "@okta/oauth2-flows@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@okta/oauth2-flows/-/oauth2-flows-0.6.0.tgz#1df28e8167b67912dfca31bd755593aa1f66425d"
   integrity sha512-wCReTJegsaRYeycPcXeuyuPlQ2G5ZA6ttTJ/Is4rvBDCOQk8vMEq+B8Sd3n1v8tOddWP2HTRiIffu/92PqXRRQ==
@@ -1664,10 +1664,15 @@
   optionalDependencies:
     fsevents "*"
 
-"@okta/spa-platform@^0.6.0":
+"@okta/spa-platform@*", "@okta/spa-platform@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@okta/spa-platform/-/spa-platform-0.6.0.tgz#ac232752117835f7815459e7ce7d1f622c241953"
   integrity sha512-VCQbvbnBtpwXBMg98ysRMyvdgjqj03wqPYEda4wyHEo31NN+KwzbwOaNAlxzg0+04MT2iDB0S+krA6MYGXA59w==
+
+"@oxc-project/types@=0.144.0":
+  version "0.144.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.144.0.tgz#7dfbfbfbbb9c24d4abeb6f9856a1eca02aff6468"
+  integrity sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==
 
 "@peculiar/asn1-schema@^2.7.0":
   version "2.8.0"
@@ -1743,10 +1748,85 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
   integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
 
+"@rolldown/binding-android-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz#9ac390255ded738672ad1425bed6423453ff71fd"
+  integrity sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==
+
+"@rolldown/binding-darwin-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz#c63cad2f656b672782dd70894af895af9cba35c8"
+  integrity sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==
+
+"@rolldown/binding-darwin-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz#54f6305d6785793c63c1521a4da4412bf7d8e089"
+  integrity sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==
+
+"@rolldown/binding-freebsd-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz#c069a3ebd4a5dcfffd79a00f33c06bc242d9566b"
+  integrity sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz#cff0d05a56e19f02443313f2abf73cf693173867"
+  integrity sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==
+
+"@rolldown/binding-linux-arm64-gnu@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz#267605366ba2bf3146609417a6db99253943c96f"
+  integrity sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==
+
+"@rolldown/binding-linux-arm64-musl@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz#73d47bfdba2a72c16bfb271c23efb8949b2c2018"
+  integrity sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==
+
+"@rolldown/binding-linux-ppc64-gnu@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz#3ba455c72d3e9efd973df59689d48e75ca6f7559"
+  integrity sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==
+
+"@rolldown/binding-linux-s390x-gnu@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz#2fddcb48eee12a620735c83a0056307b6ede2edb"
+  integrity sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==
+
+"@rolldown/binding-linux-x64-gnu@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz#97fb91430f78e46f81d4fe82a049a8c47f4ece96"
+  integrity sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==
+
+"@rolldown/binding-linux-x64-musl@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz#71ec9967b5ff546a6d5dda16d1c7a97e50bf647a"
+  integrity sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==
+
+"@rolldown/binding-openharmony-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz#1e19ab28fbdb009cb6d9503e3ff6cbeffd7225ae"
+  integrity sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==
+
+"@rolldown/binding-win32-arm64-msvc@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz#9fad167d015c699f4375c2a1d04d1e52e4a32de4"
+  integrity sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==
+
+"@rolldown/binding-win32-x64-msvc@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz#7a5f2d3e886c357029332b53f38ad2042e4615c4"
+  integrity sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==
+
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz#47d2bf4cef6d470b22f5831b420f8964e0bf755f"
   integrity sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==
+
+"@rolldown/pluginutils@^1.0.0", "@rolldown/pluginutils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
 "@rollup/plugin-babel@^7.1.0":
   version "7.1.0"
@@ -2251,6 +2331,11 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
   integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
+"@types/react-dom@^19.2.4":
+  version "19.2.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.4.tgz#165ab5e97dfb081847b0f6755060cf40a3f6666b"
+  integrity sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==
+
 "@types/react-router-dom@^5.1.6", "@types/react-router-dom@^5.3.3":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
@@ -2292,6 +2377,13 @@
   integrity sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.2.2"
+
+"@types/react@^19.2.18":
+  version "19.2.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.18.tgz#eb0b6a1fb635d1a9692d5f84a3495bd8ad153707"
+  integrity sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==
+  dependencies:
     csstype "^3.2.2"
 
 "@types/scheduler@*":
@@ -2469,6 +2561,13 @@
     "@rolldown/pluginutils" "1.0.0-beta.27"
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
+
+"@vitejs/plugin-react@^6.0.5":
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz#48ee7951093ff9054952cff9d64e874355cde372"
+  integrity sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==
+  dependencies:
+    "@rolldown/pluginutils" "^1.0.1"
 
 "@vitest/pretty-format@2.1.9":
   version "2.1.9"
@@ -3747,6 +3846,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-es@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-3.1.1.tgz#c4a8a16cf88cb5a185b23f4a61d6e9a85eb53287"
+  integrity sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==
+
 core-js-compat@^3.43.0, core-js-compat@^3.48.0:
   version "3.49.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.49.0.tgz#06145447d92f4aaf258a0c44f24b47afaeaffef6"
@@ -4081,6 +4185,11 @@ delegate@^3.1.2:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
   integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
+
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -7066,6 +7175,80 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
+lightningcss-android-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
+  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
+
+lightningcss-darwin-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
+
+lightningcss-darwin-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
+  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
+
+lightningcss-freebsd-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
+  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
+
+lightningcss-linux-arm-gnueabihf@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
+  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
+
+lightningcss-linux-arm64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
+  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
+
+lightningcss-linux-arm64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
+  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
+
+lightningcss-linux-x64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
+  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
+
+lightningcss-linux-x64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
+  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
+
+lightningcss-win32-arm64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
+  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
+
+lightningcss-win32-x64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
+  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
+
+lightningcss@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.33.0"
+    lightningcss-darwin-arm64 "1.33.0"
+    lightningcss-darwin-x64 "1.33.0"
+    lightningcss-freebsd-x64 "1.33.0"
+    lightningcss-linux-arm-gnueabihf "1.33.0"
+    lightningcss-linux-arm64-gnu "1.33.0"
+    lightningcss-linux-arm64-musl "1.33.0"
+    lightningcss-linux-x64-gnu "1.33.0"
+    lightningcss-linux-x64-musl "1.33.0"
+    lightningcss-win32-arm64-msvc "1.33.0"
+    lightningcss-win32-x64-msvc "1.33.0"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -7474,6 +7657,11 @@ nanoid@^3.3.16:
   version "3.3.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -7986,7 +8174,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatc
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4:
+picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
@@ -8031,6 +8219,15 @@ postcss@^8.4.13, postcss@^8.5.3:
   integrity sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==
   dependencies:
     nanoid "^3.3.16"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.5.25:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
+  dependencies:
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -8295,6 +8492,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-dom@^19.2.7:
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.8.tgz#3b46b9eeda877cdff2cf13d2770fff4ae36c2ec2"
+  integrity sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==
+  dependencies:
+    scheduler "^0.27.0"
+
 react-fast-compare@^3.0.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
@@ -8451,6 +8655,13 @@ react-router@6.30.4:
   dependencies:
     "@remix-run/router" "1.23.3"
 
+react-router@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-8.3.0.tgz#b7bc69c3e3833ba79ebf892aef03d62b649508f8"
+  integrity sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==
+  dependencies:
+    cookie-es "^3.1.1"
+
 react-test-renderer@^16.0.0-0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
@@ -8484,6 +8695,11 @@ react@^18.2.0:
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
+
+react@^19.2.7:
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.8.tgz#a80663dbb58d69c6fe3fd291d3cb324e8a7dff2d"
+  integrity sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==
 
 read-pkg-up@10.0.0:
   version "10.0.0"
@@ -8758,6 +8974,29 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rolldown@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.2.4.tgz#a70655fdd305b829bbc0fc598b3dd1765b4a87dc"
+  integrity sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==
+  dependencies:
+    "@oxc-project/types" "=0.144.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.2.4"
+    "@rolldown/binding-darwin-arm64" "1.2.4"
+    "@rolldown/binding-darwin-x64" "1.2.4"
+    "@rolldown/binding-freebsd-x64" "1.2.4"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.2.4"
+    "@rolldown/binding-linux-arm64-gnu" "1.2.4"
+    "@rolldown/binding-linux-arm64-musl" "1.2.4"
+    "@rolldown/binding-linux-ppc64-gnu" "1.2.4"
+    "@rolldown/binding-linux-s390x-gnu" "1.2.4"
+    "@rolldown/binding-linux-x64-gnu" "1.2.4"
+    "@rolldown/binding-linux-x64-musl" "1.2.4"
+    "@rolldown/binding-openharmony-arm64" "1.2.4"
+    "@rolldown/binding-win32-arm64-msvc" "1.2.4"
+    "@rolldown/binding-win32-x64-msvc" "1.2.4"
+
 rollup-plugin-cleanup@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.2.1.tgz#8cbc92ecf58babd7c210051929797f137bbf777c"
@@ -8939,6 +9178,11 @@ scheduler@^0.23.2:
   integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
+
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 select@^1.1.2:
   version "1.1.2"
@@ -9583,7 +9827,7 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
-tinyglobby@^0.2.13:
+tinyglobby@^0.2.13, tinyglobby@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
@@ -9986,6 +10230,19 @@ vite@^6.3.5:
     postcss "^8.5.3"
     rollup "^4.34.9"
     tinyglobby "^0.2.13"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vite@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.2.1.tgz#6fc8d8bb843bd52353091fac978e194d4de5b31d"
+  integrity sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==
+  dependencies:
+    lightningcss "^1.33.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.25"
+    rolldown "~1.2.1"
+    tinyglobby "^0.2.17"
   optionalDependencies:
     fsevents "~2.3.3"
 


### PR DESCRIPTION

Exercises the opt-in loader factories (createFetchLoader, createTokenLoader, createLoginCallbackLoader) end-to-end against a real Okta org, and resets the sign-in flow's stuck `inProgress` state on a back/forward-cache restore so an abandoned redirect doesn't block starting a new one.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers


