### PR TITLE
feat!: Add SecureOutlet, split SecureRoute/SecureOutlet into router-specific sub-exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,21 @@ module.exports = {
         node: true,
         browser: true
       }
+    },
+    {
+      // SecureRoute/SecureOutlet must import the OktaContext object via the package's
+      // own self-import so bundlers dedupe it to the same instance <Security> provides;
+      // importing it from the relative path would give this file its own separate Context.
+      files: ['src/SecureRoute.tsx', 'src/SecureOutlet.tsx'],
+      rules: {
+        'no-restricted-imports': ['error', {
+          paths: [{
+            name: './OktaContext',
+            importNames: ['default'],
+            message: "Import OktaContext from '@okta/okta-react' instead of './OktaContext' here - see the comment above this import."
+          }]
+        }]
+      }
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.0.0
+
+### Breaking Changes
+
+- `SecureRoute` and `SecureOutlet` are no longer exported from `@okta/okta-react`. Import `SecureRoute` from `@okta/okta-react/react-router-5` and `SecureOutlet` from `@okta/okta-react/react-router-6` instead. This ensures `react-router-dom` version-specific code is only pulled into your bundle if you actually use it, and avoids build-time errors from unused router APIs. Minimum supported Node version is now `12.17.0`.
+
 # 6.11.0
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ npm install --save react-router-dom     # see note below
 npm install --save @okta/okta-auth-js   # requires at least version 5.3.1
 ```
 
-> ⚠️ NOTE ⚠️<br> The [SecureRoute](#secureroute) component packaged in this SDK only works with `react-router-dom` `5.x`.
-If you're using `react-router-dom` `6.x` or later, use [SecureOutlet](#secureoutlet) instead.
+> ⚠️ NOTE ⚠️<br> The [SecureRoute](#secureroute) component only works with `react-router-dom` `5.x`, and is imported from `@okta/okta-react/react-router-5`.
+If you're using `react-router-dom` `6.x` or later, use [SecureOutlet](#secureoutlet) instead, imported from `@okta/okta-react/react-router-6`.
+
+> ⚠️ Upgrading to `7.x` ⚠️<br> As of `7.0.0`, `SecureRoute` and `SecureOutlet` are no longer exported from the `@okta/okta-react` top-level package. Update your imports to `import { SecureRoute } from '@okta/okta-react/react-router-5';` or `import { SecureOutlet } from '@okta/okta-react/react-router-6';`. This keeps `react-router-dom` version-specific code out of your bundle unless you actually use it. All other exports (`Security`, `withOktaAuth`, `useOktaAuth`, `OktaContext`, `LoginCallback`) are unaffected.
 
 ## Usage
 
@@ -152,7 +154,8 @@ This example defines 3 routes:
 
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Route, withRouter } from 'react-router-dom';
-import { SecureRoute, Security, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureRoute } from '@okta/okta-react/react-router-5';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import Home from './Home';
 import Protected from './Protected';
@@ -193,7 +196,8 @@ export default class extends Component {
 
 ```jsx
 import React from 'react';
-import { SecureRoute, Security, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureRoute } from '@okta/okta-react/react-router-5';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import { BrowserRouter as Router, Route, useHistory } from 'react-router-dom';
 import Home from './Home';
@@ -233,7 +237,8 @@ export default AppWithRouterAccess;
 
 ```jsx
 import React from 'react';
-import { SecureOutlet, Security, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureOutlet } from '@okta/okta-react/react-router-6';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-router-dom';
 import Home from './Home';
@@ -512,7 +517,7 @@ class App extends Component {
 
 ### `SecureRoute`
 
-`SecureRoute` ensures that a route is only rendered if the user is authenticated. If the user is not authenticated, it calls [onAuthRequired](#onauthrequired) if it exists, otherwise, it redirects to Okta.
+Import from `@okta/okta-react/react-router-5`. `SecureRoute` ensures that a route is only rendered if the user is authenticated. If the user is not authenticated, it calls [onAuthRequired](#onauthrequired) if it exists, otherwise, it redirects to Okta.
 
 #### onAuthRequired
 
@@ -534,7 +539,7 @@ As with `Route` from `react-router-dom`, `<SecureRoute>` can take one of:
 
 ### `SecureOutlet`
 
-`SecureOutlet` is the `react-router-dom` `6.x`+ equivalent of [SecureRoute](#secureroute). It renders an `Outlet` for its nested routes only if the user is authenticated. If the user is not authenticated, it calls [onAuthRequired](#onauthrequired) if it exists, otherwise, it redirects to Okta.
+Import from `@okta/okta-react/react-router-6`. `SecureOutlet` is the `react-router-dom` `6.x`+ equivalent of [SecureRoute](#secureroute). It renders an `Outlet` for its nested routes only if the user is authenticated. If the user is not authenticated, it calls [onAuthRequired](#onauthrequired) if it exists, otherwise, it redirects to Okta.
 
 Use it as the `element` of a parent `Route` that wraps the routes you want to protect:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ npm install --save @okta/okta-auth-js   # requires at least version 5.3.1
 ```
 
 > ⚠️ NOTE ⚠️<br> The [SecureRoute](#secureroute) component packaged in this SDK only works with `react-router-dom` `5.x`.
-If you're using `react-router-dom` `6.x`, you'll have to write your own `SecureRoute` component.<br><br>See these [samples](https://github.com/okta/okta-react/tree/master/samples/routing) to get started
+If you're using `react-router-dom` `6.x` or later, use [SecureOutlet](#secureoutlet) instead.
 
 ## Usage
 
@@ -111,10 +111,8 @@ If you're using `react-router-dom` `6.x`, you'll have to write your own `SecureR
 
 `okta-react` provides a number of pre-built components to connect a `react-router`-based SPA to Okta OIDC information.  You can use these components directly, or use them as a basis for building your own components.
 
-- [SecureRoute](#secureroute) - A normal `Route` except authentication is needed to render the component.
-
-> ⚠️ NOTE ⚠️<br> The [SecureRoute](#secureroute) component packaged in this SDK only works with `react-router-dom` `5.x`.
-If you're using `react-router-dom` `6.x`, you'll have to write your own `SecureRoute` component.<br><br>See these [samples](https://github.com/okta/okta-react/tree/master/samples/routing) to get started
+- [SecureRoute](#secureroute) - A normal `Route` except authentication is needed to render the component. Only works with `react-router-dom` `5.x`.
+- [SecureOutlet](#secureoutlet) - A normal `Outlet` except authentication is needed to render the nested routes. Works with `react-router-dom` `6.x` and later.
 
 ### General components
 
@@ -218,6 +216,50 @@ const App = () => {
       <Route path='/' exact={true} component={Home} />
       <SecureRoute path='/protected' component={Protected} />
       <Route path='/login/callback' component={LoginCallback} />
+    </Security>
+  );
+};
+
+const AppWithRouterAccess = () => (
+  <Router>
+    <App />
+  </Router>
+);
+
+export default AppWithRouterAccess;
+```
+
+#### Creating React Router v6+ Routes with SecureOutlet
+
+```jsx
+import React from 'react';
+import { SecureOutlet, Security, LoginCallback } from '@okta/okta-react';
+import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
+import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-router-dom';
+import Home from './Home';
+import Protected from './Protected';
+
+const oktaAuth = new OktaAuth({
+  issuer: 'https://{yourOktaDomain}/oauth2/default',
+  clientId: '{clientId}',
+  redirectUri: window.location.origin + '/login/callback'
+});
+
+const App = () => {
+  const navigate = useNavigate();
+  const restoreOriginalUri = async (_oktaAuth, originalUri) => {
+    navigate(toRelativeUrl(originalUri || '/', window.location.origin));
+  };
+
+  return (
+    <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+      <Routes>
+        <Route path='/' element={<Home />} />
+        <Route path='/login/callback' element={<LoginCallback />} />
+        <Route element={<SecureOutlet />}>
+          <Route path='/protected' element={<Protected />} />
+        </Route>
+      </Routes>
     </Security>
   );
 };
@@ -489,6 +531,30 @@ As with `Route` from `react-router-dom`, `<SecureRoute>` can take one of:
 - a `component` prop that is passed a component
 - a `render` prop that is passed a function that returns a component.  This function will be passed any additional props that react-router injects (such as `history` or `match`)
 - children components
+
+### `SecureOutlet`
+
+`SecureOutlet` is the `react-router-dom` `6.x`+ equivalent of [SecureRoute](#secureroute). It renders an `Outlet` for its nested routes only if the user is authenticated. If the user is not authenticated, it calls [onAuthRequired](#onauthrequired) if it exists, otherwise, it redirects to Okta.
+
+Use it as the `element` of a parent `Route` that wraps the routes you want to protect:
+
+```jsx
+<Route element={<SecureOutlet />}>
+  <Route path='/protected' element={<Protected />} />
+</Route>
+```
+
+#### onAuthRequired
+
+`SecureOutlet` accepts `onAuthRequired` as an optional prop, it overrides [onAuthRequired](#onauthrequired) from the [Security](#security) component if exists.
+
+#### errorComponent
+
+`SecureOutlet` runs internal `handleLogin` process which may throw Error when `authState.isAuthenticated` is false. By default, the Error will be rendered with `OktaError` component. If you wish to customise the display of such error messages, you can pass your own component as an `errorComponent` prop to `<SecureOutlet>`.  The error value will be passed to the `errorComponent` as the `error` prop.
+
+#### loadingElement
+
+By default, `SecureOutlet` will display nothing while the user is not yet authenticated. If you wish to customize this, you can pass your React element (not component) as `loadingElement` prop to `<SecureOutlet>`. Example: `<p>Loading...</p>`
 
 ### `LoginCallback`
 

--- a/build.js
+++ b/build.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 
 const NPM_DIR = `dist`;
 const BUNDLE_CMD = 'yarn bundle';
+const TYPES_CMD = 'yarn types';
 const BANNER_CMD = `yarn banners`;
 
 shell.echo(`Start building...`);
@@ -15,6 +16,13 @@ shell.rm(`-Rf`, `${NPM_DIR}/*`);
 // Bundle with rollup
 if (shell.exec(BUNDLE_CMD).code !== 0) {
   shell.echo(chalk.red(`Error: Rollup failed`));
+  shell.exit(1);
+}
+
+// Emit type declarations (kept separate from the rollup bundles above so the
+// multiple entry points don't fight over writing .d.ts files to the same directory)
+if (shell.exec(TYPES_CMD).code !== 0) {
+  shell.echo(chalk.red(`Error: Type declaration generation failed`));
   shell.exit(1);
 }
 

--- a/build.js
+++ b/build.js
@@ -38,9 +38,17 @@ delete packageJSON.workspaces; // remove yarn workspace section
 
 // Remove "build/" from the entrypoint paths.
 ['main', 'module', 'types'].forEach(function(key) {
-  if (packageJSON[key]) { 
+  if (packageJSON[key]) {
     packageJSON[key] = packageJSON[key].replace(`${NPM_DIR}/`, '');
   }
+});
+
+['.', './react-router-5', './react-router-6'].forEach(function(name) {
+  ['types', 'import', 'require', 'default'].forEach(function(key) {
+    if (packageJSON['exports'][name][key]) {
+      packageJSON['exports'][name][key] = packageJSON['exports'][name][key].replace(`${NPM_DIR}/`, '');
+    }
+  });
 });
 
 fs.writeFileSync(`./${NPM_DIR}/package.json`, JSON.stringify(packageJSON, null, 4));

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,11 @@ module.exports = {
     // avoid react conflict in yarn workspace
     '^react$': '<rootDir>/node_modules/react',
     '^react-dom$': '<rootDir>/node_modules/react-dom',
-    '^react-router-dom$': '<rootDir>/node_modules/react-router-dom'
+    '^react-router-dom$': '<rootDir>/node_modules/react-router-dom',
+    // resolve self-imports of OktaContext used by SecureRoute/SecureOutlet
+    '^@okta/okta-react$': '<rootDir>/src',
+    '^@okta/okta-react/react-router-5$': '<rootDir>/src/react-router-5.ts',
+    '^@okta/okta-react/react-router-6$': '<rootDir>/src/react-router-6.ts'
   },
   roots: [
     './test/jest'

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
     "react-dom": ">=16.8.0",
     "react-router-dom": ">=5.1.0"
   },
+  "peerDependenciesMeta": {
+    "react-router-dom": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.3",
@@ -106,6 +111,7 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-router-dom": "5.2.0",
+    "react-router-dom-v6": "npm:react-router-dom@^6.4.0",
     "rollup": "^4.62.3",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-terser": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e": "yarn workspace @okta/test.e2e test",
     "test:unit": "jest",
     "bundle": "rollup -c",
+    "types": "tsc -p tsconfig.json --declaration --emitDeclarationOnly --declarationDir dist/bundles/types",
     "dev": "yarn bundle --watch",
     "generate": "yarn --cwd generator install && yarn --cwd generator generate"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-react",
-  "version": "6.12.0",
+  "version": "7.0.0",
   "description": "React support for Okta",
   "private": true,
   "scripts": {
@@ -29,6 +29,25 @@
   "main": "dist/bundles/okta-react.cjs.js",
   "module": "dist/bundles/okta-react.esm.js",
   "types": "dist/bundles/types",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/bundles/types/index.d.ts",
+      "import": "./dist/bundles/okta-react.esm.js",
+      "require": "./dist/bundles/okta-react.cjs.js",
+      "default": "./dist/bundles/okta-react.umd.js"
+    },
+    "./react-router-5": {
+      "types": "./dist/bundles/types/react-router-5.d.ts",
+      "import": "./dist/bundles/okta-react-router-5.esm.js",
+      "require": "./dist/bundles/okta-react-router-5.cjs.js"
+    },
+    "./react-router-6": {
+      "types": "./dist/bundles/types/react-router-6.d.ts",
+      "import": "./dist/bundles/okta-react-router-6.esm.js",
+      "require": "./dist/bundles/okta-react-router-6.cjs.js"
+    }
+  },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
@@ -36,7 +55,7 @@
   },
   "homepage": "https://github.com/okta/okta-react#readme",
   "engines": {
-    "node": ">=10.3",
+    "node": ">=12.17.0",
     "yarn": "^1.7.0"
   },
   "resolutions": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ const makeExternalPredicate = () => {
   const externalArr = [
     ...Object.keys(pkg.peerDependencies || {}),
     ...Object.keys(pkg.dependencies || {}),
+    '@okta/okta-react',
   ];
 
   if (externalArr.length === 0) {
@@ -26,10 +27,24 @@ const extensions = ['js', 'jsx', 'ts', 'tsx'];
 
 const input = 'src/index.ts';
 const external = makeExternalPredicate();
-const commonPlugins = [
+
+// Each build below needs its own `typescript()` plugin instance (with its own cacheRoot).
+// Sharing a single instance across configs with different inputs confuses rollup-plugin-typescript2's
+// declaration-emit bookkeeping and causes spurious "would overwrite input file" (TS5055) errors.
+// The first (UMD) build below type-checks the whole `src/**/*` program (per tsconfig's `include`)
+// and already produces every .d.ts file we need at `dist/bundles/types`; the later builds redirect
+// their (unused) declaration output elsewhere so they can't collide with those canonical files.
+const commonPlugins = (cacheRoot, emitDeclarationsTo = 'dist/bundles/types') => [
   typescript({
     typescript: ts,
-    useTsconfigDeclarationDir: true
+    useTsconfigDeclarationDir: true,
+    cacheRoot: `./node_modules/.cache/rpt2_${cacheRoot}`,
+    tsconfigOverride: {
+      compilerOptions: {
+        rootDir: 'src',
+        declarationDir: emitDeclarationsTo
+      }
+    }
   }),
   replace({
     values: {
@@ -45,7 +60,7 @@ const commonPlugins = [
     delimiters: ['\\b', '\\b'],
     preventAssignment: true
   }),
-  cleanup({ 
+  cleanup({
     extensions,
     comments: 'none'
   })
@@ -56,7 +71,7 @@ export default [
     input,
     external,
     plugins: [
-      ...commonPlugins,
+      ...commonPlugins('umd'),
       babel({
         babelrc: false,
         babelHelpers: 'bundled',
@@ -85,7 +100,7 @@ export default [
     input: 'src/index.ts',
     external,
     plugins: [
-      ...commonPlugins,
+      ...commonPlugins('index', './node_modules/.cache/rpt2_index_types'),
       babel({
         babelHelpers: 'runtime',
         presets: [
@@ -108,6 +123,70 @@ export default [
       {
         format: 'esm',
         file: 'dist/bundles/okta-react.esm.js',
+        exports: 'named',
+        sourcemap: true
+      }
+    ]
+  },
+  {
+    input: 'src/react-router-5.ts',
+    external,
+    plugins: [
+      ...commonPlugins('react-router-5', './node_modules/.cache/rpt2_react-router-5_types'),
+      babel({
+        babelHelpers: 'runtime',
+        presets: [
+          '@babel/preset-env',
+          '@babel/preset-react'
+        ],
+        plugins: [
+          '@babel/plugin-transform-runtime'
+        ],
+        extensions
+      }),
+    ],
+    output: [
+      {
+        format: 'cjs',
+        file: 'dist/bundles/okta-react-router-5.cjs.js',
+        exports: 'named',
+        sourcemap: true
+      },
+      {
+        format: 'esm',
+        file: 'dist/bundles/okta-react-router-5.esm.js',
+        exports: 'named',
+        sourcemap: true
+      }
+    ]
+  },
+  {
+    input: 'src/react-router-6.ts',
+    external,
+    plugins: [
+      ...commonPlugins('react-router-6', './node_modules/.cache/rpt2_react-router-6_types'),
+      babel({
+        babelHelpers: 'runtime',
+        presets: [
+          '@babel/preset-env',
+          '@babel/preset-react'
+        ],
+        plugins: [
+          '@babel/plugin-transform-runtime'
+        ],
+        extensions
+      }),
+    ],
+    output: [
+      {
+        format: 'cjs',
+        file: 'dist/bundles/okta-react-router-6.cjs.js',
+        exports: 'named',
+        sourcemap: true
+      },
+      {
+        format: 'esm',
+        file: 'dist/bundles/okta-react-router-6.esm.js',
         exports: 'named',
         sourcemap: true
       }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,23 +28,12 @@ const extensions = ['js', 'jsx', 'ts', 'tsx'];
 const input = 'src/index.ts';
 const external = makeExternalPredicate();
 
-// Each build below needs its own `typescript()` plugin instance (with its own cacheRoot).
-// Sharing a single instance across configs with different inputs confuses rollup-plugin-typescript2's
-// declaration-emit bookkeeping and causes spurious "would overwrite input file" (TS5055) errors.
-// The first (UMD) build below type-checks the whole `src/**/*` program (per tsconfig's `include`)
-// and already produces every .d.ts file we need at `dist/bundles/types`; the later builds redirect
-// their (unused) declaration output elsewhere so they can't collide with those canonical files.
-const commonPlugins = (cacheRoot, emitDeclarationsTo = 'dist/bundles/types') => [
+// Type declarations are emitted separately (see `yarn types`, a single whole-program
+// `tsc --emitDeclarationOnly` pass) rather than by this plugin, so multiple entry points
+// below can share one `typescript()` instance without fighting over declaration output.
+const commonPlugins = [
   typescript({
-    typescript: ts,
-    useTsconfigDeclarationDir: true,
-    cacheRoot: `./node_modules/.cache/rpt2_${cacheRoot}`,
-    tsconfigOverride: {
-      compilerOptions: {
-        rootDir: 'src',
-        declarationDir: emitDeclarationsTo
-      }
-    }
+    typescript: ts
   }),
   replace({
     values: {
@@ -71,7 +60,7 @@ export default [
     input,
     external,
     plugins: [
-      ...commonPlugins('umd'),
+      ...commonPlugins,
       babel({
         babelrc: false,
         babelHelpers: 'bundled',
@@ -100,7 +89,7 @@ export default [
     input: 'src/index.ts',
     external,
     plugins: [
-      ...commonPlugins('index', './node_modules/.cache/rpt2_index_types'),
+      ...commonPlugins,
       babel({
         babelHelpers: 'runtime',
         presets: [
@@ -132,7 +121,7 @@ export default [
     input: 'src/react-router-5.ts',
     external,
     plugins: [
-      ...commonPlugins('react-router-5', './node_modules/.cache/rpt2_react-router-5_types'),
+      ...commonPlugins,
       babel({
         babelHelpers: 'runtime',
         presets: [
@@ -164,7 +153,7 @@ export default [
     input: 'src/react-router-6.ts',
     external,
     plugins: [
-      ...commonPlugins('react-router-6', './node_modules/.cache/rpt2_react-router-6_types'),
+      ...commonPlugins,
       babel({
         babelHelpers: 'runtime',
         presets: [

--- a/samples/custom-login/src/App.jsx
+++ b/samples/custom-login/src/App.jsx
@@ -13,7 +13,8 @@
 import React from 'react';
 import { Route, useHistory, Switch } from 'react-router-dom';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
-import { Security, SecureRoute, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureRoute } from '@okta/okta-react/react-router-5';
 import { Container } from 'semantic-ui-react';
 import config from './config';
 import Home from './Home';

--- a/samples/doc-direct-auth/src/App.jsx
+++ b/samples/doc-direct-auth/src/App.jsx
@@ -12,7 +12,8 @@
 
 import React from 'react';
 import { Route, useHistory } from 'react-router-dom';
-import { Security, SecureRoute, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureRoute } from '@okta/okta-react/react-router-5';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import Home from './Home';
 import Login from './Login';

--- a/samples/doc-embedded-widget/src/App.jsx
+++ b/samples/doc-embedded-widget/src/App.jsx
@@ -12,7 +12,8 @@
 
 import React from 'react';
 import { Route, useHistory } from 'react-router-dom';
-import { Security, SecureRoute, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureRoute } from '@okta/okta-react/react-router-5';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
 import Home from './Home';
 import Login from './Login';

--- a/samples/okta-hosted-login/src/App.jsx
+++ b/samples/okta-hosted-login/src/App.jsx
@@ -13,7 +13,8 @@
 import React from 'react';
 import { Route, useHistory, Switch } from 'react-router-dom';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
-import { Security, SecureRoute, LoginCallback } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureRoute } from '@okta/okta-react/react-router-5';
 import { Container } from 'semantic-ui-react';
 import config from './config';
 import Home from './Home';

--- a/src/OktaContext.ts
+++ b/src/OktaContext.ts
@@ -25,6 +25,6 @@ export interface IOktaContext {
 
 const OktaContext = React.createContext<IOktaContext | null>(null);
 
-export const useOktaAuth = (): IOktaContext => React.useContext(OktaContext) as IOktaContext;
+export const useOktaAuth = (context?: typeof OktaContext): IOktaContext => React.useContext(context ?? OktaContext) as IOktaContext;
 
 export default OktaContext;

--- a/src/SecureOutlet.tsx
+++ b/src/SecureOutlet.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as React from 'react';
+import { useOktaAuth, OnAuthRequiredFunction } from './OktaContext';
+import * as ReactRouterDom from 'react-router-dom';
+import { toRelativeUrl, AuthSdkError } from '@okta/okta-auth-js';
+import OktaError from './OktaError';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Outlet: any;
+if ('Outlet' in ReactRouterDom) {
+  // trick static analyzer to avoid "'Outlet' is not exported" error
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Outlet = (ReactRouterDom as any)['Outlet' in ReactRouterDom ? 'Outlet' : ''];
+} else {
+  // throw when Outlet is rendered
+  Outlet = () => {
+    throw new AuthSdkError('Unsupported: SecureOutlet only works with react-router-dom v6 or any router library with compatible APIs. See examples under the "samples" folder for how to implement your own custom SecureRoute Component.');
+  };
+}
+
+export interface SecureOutletProps {
+  onAuthRequired?: OnAuthRequiredFunction;
+  errorComponent?: React.ComponentType<{ error: Error }>;
+  loadingElement?: React.ReactElement | null;
+}
+
+const SecureOutlet: React.FC<SecureOutletProps & React.HTMLAttributes<HTMLDivElement>> = ({
+  onAuthRequired,
+  errorComponent,
+  loadingElement = null,
+  ...outletProps
+}) => {
+  const { oktaAuth, authState, _onAuthRequired } = useOktaAuth();
+  const pendingLogin = React.useRef(false);
+  const [handleLoginError, setHandleLoginError] = React.useState<Error | null>(null);
+  const ErrorReporter = errorComponent || OktaError;
+
+  React.useEffect(() => {
+    const handleLogin = async () => {
+      if (pendingLogin.current) {
+        return;
+      }
+
+      pendingLogin.current = true;
+
+      const originalUri = toRelativeUrl(window.location.href, window.location.origin);
+      oktaAuth.setOriginalUri(originalUri);
+      const onAuthRequiredFn = onAuthRequired || _onAuthRequired;
+      if (onAuthRequiredFn) {
+        await onAuthRequiredFn(oktaAuth);
+      } else {
+        await oktaAuth.signInWithRedirect();
+      }
+    };
+
+    if (!authState) {
+      return;
+    }
+
+    if (authState.isAuthenticated) {
+      pendingLogin.current = false;
+      return;
+    }
+
+    // Start login if app has decided it is not logged in and there is no pending signin
+    if (!authState.isAuthenticated) {
+      handleLogin().catch(err => {
+        setHandleLoginError(err as Error);
+      });
+    }
+
+  }, [
+    authState,
+    oktaAuth,
+    onAuthRequired,
+    _onAuthRequired
+  ]);
+
+  if (handleLoginError) {
+    return <ErrorReporter error={handleLoginError} />;
+  }
+
+  if (authState?.isAuthenticated) {
+    return (
+      <Outlet
+        { ...outletProps }
+      />
+    );
+  }
+
+  return loadingElement;
+};
+
+export default SecureOutlet;

--- a/src/SecureOutlet.tsx
+++ b/src/SecureOutlet.tsx
@@ -14,6 +14,11 @@ import * as React from 'react';
 import { useOktaAuth, OnAuthRequiredFunction } from './OktaContext';
 import * as ReactRouterDom from 'react-router-dom';
 import { toRelativeUrl, AuthSdkError } from '@okta/okta-auth-js';
+// Important! Don't import OktaContext from './OktaContext'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { OktaContext } from '@okta/okta-react';
 import OktaError from './OktaError';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,7 +46,9 @@ const SecureOutlet: React.FC<SecureOutletProps & React.HTMLAttributes<HTMLDivEle
   loadingElement = null,
   ...outletProps
 }) => {
-  const { oktaAuth, authState, _onAuthRequired } = useOktaAuth();
+  // Need to use OktaContext imported from `@okta/okta-react`
+  // Because SecureOutlet needs to be imported from `@okta/okta-react/react-router-6`
+  const { oktaAuth, authState, _onAuthRequired } = useOktaAuth(OktaContext);
   const pendingLogin = React.useRef(false);
   const [handleLoginError, setHandleLoginError] = React.useState<Error | null>(null);
   const ErrorReporter = errorComponent || OktaError;

--- a/src/SecureRoute.tsx
+++ b/src/SecureRoute.tsx
@@ -14,6 +14,11 @@ import * as React from 'react';
 import { useOktaAuth, OnAuthRequiredFunction } from './OktaContext';
 import * as ReactRouterDom from 'react-router-dom';
 import { toRelativeUrl, AuthSdkError } from '@okta/okta-auth-js';
+// Important! Don't import OktaContext from './OktaContext'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { OktaContext } from '@okta/okta-react';
 import OktaError from './OktaError';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,7 +42,9 @@ const SecureRoute: React.FC<{
   errorComponent,
   ...routeProps
 }) => { 
-  const { oktaAuth, authState, _onAuthRequired } = useOktaAuth();
+  // Need to use OktaContext imported from `@okta/okta-react`
+  // Because SecureRoute needs to be imported from `@okta/okta-react/react-router-5`
+  const { oktaAuth, authState, _onAuthRequired } = useOktaAuth(OktaContext);
   const match = useMatch(routeProps);
   const pendingLogin = React.useRef(false);
   const [handleLoginError, setHandleLoginError] = React.useState<Error | null>(null);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import withOktaAuth from './withOktaAuth';
 import OktaContext, { useOktaAuth } from './OktaContext';
 import LoginCallback from './LoginCallback';
 import SecureRoute from './SecureRoute';
+import SecureOutlet from './SecureOutlet';
 
 export {
   Security,
@@ -23,4 +24,5 @@ export {
   OktaContext,
   LoginCallback,
   SecureRoute,
+  SecureOutlet,
 };

--- a/src/react-router-5.ts
+++ b/src/react-router-5.ts
@@ -10,15 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import Security from './Security';
-import withOktaAuth from './withOktaAuth';
-import OktaContext, { useOktaAuth } from './OktaContext';
-import LoginCallback from './LoginCallback';
+import SecureRoute from './SecureRoute';
 
 export {
-  Security,
-  withOktaAuth,
-  useOktaAuth,
-  OktaContext,
-  LoginCallback,
+  SecureRoute,
 };

--- a/src/react-router-6.ts
+++ b/src/react-router-6.ts
@@ -10,15 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import Security from './Security';
-import withOktaAuth from './withOktaAuth';
-import OktaContext, { useOktaAuth } from './OktaContext';
-import LoginCallback from './LoginCallback';
+import SecureOutlet from './SecureOutlet';
 
 export {
-  Security,
-  withOktaAuth,
-  useOktaAuth,
-  OktaContext,
-  LoginCallback,
+  SecureOutlet,
 };

--- a/test/apps/test-harness-app/src/App.tsx
+++ b/test/apps/test-harness-app/src/App.tsx
@@ -13,7 +13,8 @@
 import * as React from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
 import { OktaAuth, toRelativeUrl } from '@okta/okta-auth-js';
-import { Security, LoginCallback, SecureRoute } from '@okta/okta-react';
+import { Security, LoginCallback } from '@okta/okta-react';
+import { SecureRoute } from '@okta/okta-react/react-router-5';
 import Home from './Home';
 import Protected from './Protected';
 import CustomLogin from './CustomLogin';

--- a/test/jest/secureOutlet.test.tsx
+++ b/test/jest/secureOutlet.test.tsx
@@ -1,0 +1,337 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+jest.mock('react-router-dom', () => jest.requireActual('react-router-dom-v6'));
+
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import SecureOutlet from '../../src/SecureOutlet';
+import Security from '../../src/Security';
+import OktaContext from '../../src/OktaContext';
+
+describe('<SecureOutlet />', () => {
+  let oktaAuth;
+  let authState;
+  let mockProps;
+  const restoreOriginalUri = async (_, url) => {
+    location.href = url;
+  };
+
+  beforeEach(() => {
+    authState = null;
+    oktaAuth = {
+      options: {},
+      authStateManager: {
+        getAuthState: jest.fn().mockImplementation(() => authState),
+        subscribe: jest.fn(),
+        unsubscribe: jest.fn(),
+        updateAuthState: jest.fn(),
+      },
+      isLoginRedirect: jest.fn().mockImplementation(() => false),
+      handleLoginRedirect: jest.fn(),
+      signInWithRedirect: jest.fn(),
+      setOriginalUri: jest.fn(),
+      start: jest.fn(),
+    };
+    mockProps = {
+      oktaAuth,
+      restoreOriginalUri
+    };
+  });
+
+  describe('With changing authState', () => {
+    let emitAuthState;
+
+    beforeEach(() => {
+      oktaAuth.authStateManager.subscribe = (cb) => {
+        emitAuthState = () => {
+          act(cb.bind(null, authState));
+        };
+      };
+    });
+
+    function updateAuthState(newProps = {}) {
+      authState = Object.assign({}, authState || {}, newProps);
+      emitAuthState();
+    }
+
+    it('calls login() only once until user is authenticated', () => {
+      authState = {
+        isAuthenticated: false
+      };
+
+      mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <Routes>
+              <Route path="/" element={<SecureOutlet />} />
+            </Routes>
+          </Security>
+        </MemoryRouter>
+      );
+      expect(oktaAuth.signInWithRedirect).toHaveBeenCalledTimes(1);
+      oktaAuth.signInWithRedirect.mockClear();
+
+      updateAuthState(null);
+      expect(oktaAuth.signInWithRedirect).not.toHaveBeenCalled();
+
+      updateAuthState({});
+      expect(oktaAuth.signInWithRedirect).not.toHaveBeenCalled();
+
+      updateAuthState({ isAuthenticated: true });
+      expect(oktaAuth.signInWithRedirect).not.toHaveBeenCalled();
+
+      // If the state returns to unauthenticated, the secure outlet should still work
+      updateAuthState({ isAuthenticated: false });
+      expect(oktaAuth.signInWithRedirect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('isAuthenticated: true', () => {
+
+    beforeEach(() => {
+      authState = {
+        isAuthenticated: true
+      };
+    });
+
+    it('will render nested route content via Outlet', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter initialEntries={['/']}>
+          <Security {...mockProps}>
+            <Routes>
+              <Route path="/" element={<SecureOutlet />}>
+                <Route index element={<MyComponent />} />
+              </Route>
+            </Routes>
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
+  });
+
+  describe('isAuthenticated: false', () => {
+
+    beforeEach(() => {
+      authState = {
+        isAuthenticated: false
+      };
+    });
+
+    it('will not render nested route content', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter initialEntries={['/']}>
+          <Security {...mockProps}>
+            <Routes>
+              <Route path="/" element={<SecureOutlet />}>
+                <Route index element={<MyComponent />} />
+              </Route>
+            </Routes>
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).length).toBe(0);
+    });
+
+    describe('authState is not null', () => {
+
+      beforeEach(() => {
+        authState = {};
+      });
+
+      it('calls signInWithRedirect()', () => {
+        mount(
+          <MemoryRouter>
+            <Security {...mockProps}>
+              <Routes>
+                <Route path="/" element={<SecureOutlet />} />
+              </Routes>
+            </Security>
+          </MemoryRouter>
+        );
+        expect(oktaAuth.setOriginalUri).toHaveBeenCalled();
+        expect(oktaAuth.signInWithRedirect).toHaveBeenCalled();
+      });
+
+      it('calls onAuthRequired if provided from Security', () => {
+        const onAuthRequired = jest.fn();
+        mount(
+          <MemoryRouter>
+            <Security {...mockProps} onAuthRequired={onAuthRequired}>
+              <Routes>
+                <Route path="/" element={<SecureOutlet />} />
+              </Routes>
+            </Security>
+          </MemoryRouter>
+        );
+        expect(oktaAuth.setOriginalUri).toHaveBeenCalled();
+        expect(oktaAuth.signInWithRedirect).not.toHaveBeenCalled();
+        expect(onAuthRequired).toHaveBeenCalledWith(oktaAuth);
+      });
+
+      it('calls onAuthRequired from SecureOutlet if provided from both Security and SecureOutlet', () => {
+        const onAuthRequired1 = jest.fn();
+        const onAuthRequired2 = jest.fn();
+        mount(
+          <MemoryRouter>
+            <Security {...mockProps} onAuthRequired={onAuthRequired1}>
+              <Routes>
+                <Route path="/" element={<SecureOutlet onAuthRequired={onAuthRequired2} />} />
+              </Routes>
+            </Security>
+          </MemoryRouter>
+        );
+        expect(oktaAuth.setOriginalUri).toHaveBeenCalled();
+        expect(oktaAuth.signInWithRedirect).not.toHaveBeenCalled();
+        expect(onAuthRequired1).not.toHaveBeenCalled();
+        expect(onAuthRequired2).toHaveBeenCalledWith(oktaAuth);
+      });
+    });
+
+    describe('authState is null', () => {
+
+      beforeEach(() => {
+        authState = null;
+      });
+
+      it('does not call signInWithRedirect()', () => {
+        mount(
+          <MemoryRouter>
+            <Security {...mockProps}>
+              <Routes>
+                <Route path="/" element={<SecureOutlet />} />
+              </Routes>
+            </Security>
+          </MemoryRouter>
+        );
+        expect(oktaAuth.signInWithRedirect).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('loadingElement', () => {
+    let container = null;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      authState = {
+        isAuthenticated: false
+      };
+    });
+
+    afterEach(() => {
+      unmountComponentAtNode(container);
+      container.remove();
+      container = null;
+    });
+
+    it('renders nothing by default', async () => {
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <Security {...mockProps}>
+              <Routes>
+                <Route path="/" element={<SecureOutlet />} />
+              </Routes>
+            </Security>
+          </MemoryRouter>,
+          container
+        );
+      });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders a custom loadingElement', async () => {
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <Security {...mockProps}>
+              <Routes>
+                <Route path="/" element={<SecureOutlet loadingElement={<div>Loading...</div>} />} />
+              </Routes>
+            </Security>
+          </MemoryRouter>,
+          container
+        );
+      });
+      expect(container.innerHTML).toBe('<div>Loading...</div>');
+    });
+  });
+
+  describe('Error handling', () => {
+    let container = null;
+    beforeEach(() => {
+      // setup a DOM element as a render target
+      container = document.createElement('div');
+      document.body.appendChild(container);
+
+      authState = {
+        isAuthenticated: false
+      };
+
+      oktaAuth.setOriginalUri = jest.fn().mockImplementation(() => {
+        throw new Error(`DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.`);
+      });
+    });
+
+    afterEach(() => {
+      // cleanup on exiting
+      unmountComponentAtNode(container);
+      container.remove();
+      container = null;
+    });
+
+    it('shows error with default OktaError component', async () => {
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <OktaContext.Provider value={{
+              oktaAuth: oktaAuth,
+              authState
+            }}>
+              <SecureOutlet />
+            </OktaContext.Provider>
+          </MemoryRouter>,
+          container
+        );
+      });
+      expect(container.innerHTML).toBe('<p>Error: DOMException: Failed to read the \'sessionStorage\' property from \'Window\': Access is denied for this document.</p>');
+    });
+
+    it('shows error with provided custom error component', async () => {
+      const CustomErrorComponent = ({ error }) => {
+        return <div>Custom Error: {error.message}</div>;
+      };
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <OktaContext.Provider value={{
+              oktaAuth: oktaAuth,
+              authState
+            }}>
+              <SecureOutlet errorComponent={CustomErrorComponent} />
+            </OktaContext.Provider>
+          </MemoryRouter>,
+          container
+        );
+      });
+      expect(container.innerHTML).toBe('<div>Custom Error: DOMException: Failed to read the \'sessionStorage\' property from \'Window\': Access is denied for this document.</div>');
+    });
+  });
+});

--- a/test/jest/secureOutletWithRR5.test.tsx
+++ b/test/jest/secureOutletWithRR5.test.tsx
@@ -17,36 +17,12 @@ import { act } from 'react-dom/test-utils';
 import { render } from 'react-dom';
 import SecureOutlet from '../../src/SecureOutlet';
 import OktaContext from '../../src/OktaContext';
-import { AuthSdkError } from '@okta/okta-auth-js';
+import { ErrorBoundary } from './support/ErrorBoundary';
 
 jest.mock('react-router-dom', () => ({
   __esModule: true,
   useRouteMatch: jest.fn()
 }));
-
-class ErrorBoundary extends React.Component {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      error: null
-    } as {
-      error: AuthSdkError | null
-    };
-  }
-
-  componentDidCatch(error: AuthSdkError) {
-    this.setState({ error: error });
-  }
-
-  render() {
-    if (this.state.error) {
-      // You can render any custom fallback UI
-      return <p>{ this.state.error.toString() }</p>;
-    }
-
-    return this.props.children;
-  }
-}
 
 describe('react-router-dom v5', () => {
   let oktaAuth: any;

--- a/test/jest/secureOutletWithRR5.test.tsx
+++ b/test/jest/secureOutletWithRR5.test.tsx
@@ -1,0 +1,96 @@
+/*!
+ * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render } from 'react-dom';
+import SecureOutlet from '../../src/SecureOutlet';
+import OktaContext from '../../src/OktaContext';
+import { AuthSdkError } from '@okta/okta-auth-js';
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useRouteMatch: jest.fn()
+}));
+
+class ErrorBoundary extends React.Component {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      error: null
+    } as {
+      error: AuthSdkError | null
+    };
+  }
+
+  componentDidCatch(error: AuthSdkError) {
+    this.setState({ error: error });
+  }
+
+  render() {
+    if (this.state.error) {
+      // You can render any custom fallback UI
+      return <p>{ this.state.error.toString() }</p>;
+    }
+
+    return this.props.children;
+  }
+}
+
+describe('react-router-dom v5', () => {
+  let oktaAuth: any;
+  let authState: any;
+
+  beforeEach(() => {
+    // prevents logging error to console
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    console.error = (()=>{});   // noop
+
+    authState = {
+      isAuthenticated: true
+    };
+    oktaAuth = {
+      options: {},
+      authStateManager: {
+        getAuthState: jest.fn().mockImplementation(() => authState),
+        subscribe: jest.fn(),
+        unsubscribe: jest.fn(),
+        updateAuthState: jest.fn(),
+      },
+      isLoginRedirect: jest.fn().mockImplementation(() => false),
+      handleLoginRedirect: jest.fn(),
+      signInWithRedirect: jest.fn(),
+      setOriginalUri: jest.fn(),
+      start: jest.fn(),
+    };
+  });
+
+  it('throws unsupported error', async () => {
+    const container = document.createElement('div');
+    await act(async () => {
+      render(
+        <OktaContext.Provider value={{
+          oktaAuth: oktaAuth,
+          authState
+        }}>
+          <ErrorBoundary>
+            <SecureOutlet />
+          </ErrorBoundary>
+        </OktaContext.Provider>,
+        container
+      );
+    });
+    expect(container.innerHTML).toBe('<p>AuthSdkError: Unsupported: SecureOutlet only works with react-router-dom v6 or any router library with compatible APIs. See examples under the "samples" folder for how to implement your own custom SecureRoute Component.</p>');
+  })
+});

--- a/test/jest/secureRouteWithRR6.test.tsx
+++ b/test/jest/secureRouteWithRR6.test.tsx
@@ -17,36 +17,12 @@ import { act } from 'react-dom/test-utils';
 import { render } from 'react-dom';
 import SecureRoute from '../../src/SecureRoute';
 import OktaContext from '../../src/OktaContext';
-import { AuthSdkError } from '@okta/okta-auth-js';
+import { ErrorBoundary } from './support/ErrorBoundary';
 
 jest.mock('react-router-dom', () => ({
   __esModule: true,
   useMatch: jest.fn()
 }));
-
-class ErrorBoundary extends React.Component {
-  constructor(props: any) {
-    super(props);
-    this.state = { 
-      error: null
-    } as {
-      error: AuthSdkError | null
-    };
-  }
-
-  componentDidCatch(error: AuthSdkError) {
-    this.setState({ error: error });
-  }
-
-  render() {
-    if (this.state.error) {
-      // You can render any custom fallback UI
-      return <p>{ this.state.error.toString() }</p>;
-    }
-
-    return this.props.children; 
-  }
-}
 
 describe('react-router-dom v6', () => {
   let oktaAuth: any;
@@ -73,7 +49,7 @@ describe('react-router-dom v6', () => {
       start: jest.fn(),
     };
   });
-  
+
   it('throws unsupported error', async () => {
     const container = document.createElement('div');
     await act(async () => {

--- a/test/jest/support/ErrorBoundary.tsx
+++ b/test/jest/support/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright (c) 2017-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
@@ -10,15 +10,31 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import Security from './Security';
-import withOktaAuth from './withOktaAuth';
-import OktaContext, { useOktaAuth } from './OktaContext';
-import LoginCallback from './LoginCallback';
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
-export {
-  Security,
-  withOktaAuth,
-  useOktaAuth,
-  OktaContext,
-  LoginCallback,
-};
+import * as React from 'react';
+import { AuthSdkError } from '@okta/okta-auth-js';
+
+export class ErrorBoundary extends React.Component {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      error: null
+    } as {
+      error: AuthSdkError | null
+    };
+  }
+
+  componentDidCatch(error: AuthSdkError) {
+    this.setState({ error: error });
+  }
+
+  render() {
+    if (this.state.error) {
+      // You can render any custom fallback UI
+      return <p>{ this.state.error.toString() }</p>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/test/jest/tsconfig.json
+++ b/test/jest/tsconfig.json
@@ -4,6 +4,12 @@
     "jsx": "react",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@okta/okta-react": ["../../src"],
+      "@okta/okta-react/react-router-5": ["../../src/react-router-5.ts"],
+      "@okta/okta-react/react-router-6": ["../../src/react-router-6.ts"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-    "declaration": true,
-    "declarationDir": "dist/bundles/types",
+    "skipLibCheck": true,
     "target": "ES2019",
     "sourceMap": true,
     "jsx": "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1723,6 +1723,11 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@remix-run/router@1.23.4":
+  version "1.23.4"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.4.tgz#d2becd2afca4a40c30a659d913b9b0bcc28bced8"
+  integrity sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==
+
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz#47d2bf4cef6d470b22f5831b420f8964e0bf755f"
@@ -8328,6 +8333,14 @@ react-refresh@^0.17.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
+"react-router-dom-v6@npm:react-router-dom@^6.4.0":
+  version "6.30.6"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.6.tgz#acaf0db65efeddabd0840616243c97f578b3baf3"
+  integrity sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==
+  dependencies:
+    "@remix-run/router" "1.23.4"
+    react-router "6.30.6"
+
 react-router-dom@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
@@ -8415,6 +8428,13 @@ react-router@6.3.0:
   integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
   dependencies:
     history "^5.2.0"
+
+react-router@6.30.6:
+  version "6.30.6"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.6.tgz#a2ad70f3472de61c61e44182b3e5a25fd91f9f68"
+  integrity sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==
+  dependencies:
+    "@remix-run/router" "1.23.4"
 
 react-test-renderer@^16.0.0-0:
   version "16.14.0"


### PR DESCRIPTION
SecureRoute only worked with react-router-dom v5 APIs, forcing v6+ users to hand-roll their own guard component (see issues #267, #300). This PR adds `SecureOutlet`, which mirrors `SecureRoute`'s auth-gating behavior using `Outlet`, and then splits both components into router-version-specific sub-exports so unused router code never enters a consumer's bundle.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`SecureRoute` only works with `react-router-dom` v5 (`Route`-based) APIs. v6+ apps, which use `Outlet`-based nested routing, have no built-in guard component and must hand-roll one (#267, #300). Additionally, `SecureRoute` living in the top-level `@okta/okta-react` bundle means `react-router-dom` symbols it references are a latent bundler/type risk for *every* consumer, regardless of whether `SecureRoute` is used — this already caused a real production build break (#178/#187, patched reactively in #210/#213).

Issue Number: #267, #300


## What is the new behavior?

- Adds `SecureOutlet`, a v6+ equivalent of `SecureRoute` built on `Outlet`, with the same auth-gating behavior.
- Splits both router guard components out of the top-level `@okta/okta-react` export into dedicated sub-exports: `SecureRoute` → `@okta/okta-react/react-router-5`, `SecureOutlet` → `@okta/okta-react/react-router-6`. Each is built as its own bundle via `package.json` `exports`, so router-version-specific code is only pulled into a consumer's build when they actually import it — closing the whole class of bug behind #178/#187 rather than patching it symbol-by-symbol.
- Ports the design from the unmerged `okta/okta-react#282` (`dev7`) draft onto current tooling.
- `react-router-dom` becomes an optional peer dependency.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`SecureRoute` and `SecureOutlet` are no longer exported from `@okta/okta-react`. Consumers must update imports:

```diff
- import { SecureRoute } from '@okta/okta-react';
+ import { SecureRoute } from '@okta/okta-react/react-router-5';
```

```diff
- import { SecureOutlet } from '@okta/okta-react';
+ import { SecureOutlet } from '@okta/okta-react/react-router-6';
```

Minimum supported Node version is now `12.17.0` (required for package self-referencing via `exports`). Major version bump: `6.12.0` → `7.0.0`.


## Other information

See `CHANGELOG.md` and the updated `README.md` "Upgrading to `7.x`" note for full migration details.


## Reviewers

